### PR TITLE
遊び方ウィンドウを表示 (#6)

### DIFF
--- a/frontend/src/features/top/components/HowToDialog.tsx
+++ b/frontend/src/features/top/components/HowToDialog.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+
+type HowToDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function HowToDialog({ isOpen, onClose }: HowToDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+
+    if (!dialog) {
+      return
+    }
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal()
+    }
+
+    if (!isOpen && dialog.open) {
+      dialog.close()
+    }
+  }, [isOpen])
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="how-to-dialog-title"
+      className="modal backdrop:bg-black/70"
+      onCancel={onClose}
+      onClose={onClose}
+    >
+      <section className="modal-box max-w-2xl border-2 border-[#c6a160] bg-[#0b3022] text-[#f1d49e] shadow-2xl">
+        <h2
+          id="how-to-dialog-title"
+          className="text-center text-3xl font-bold tracking-[0.2em]"
+        >
+          遊び方
+        </h2>
+
+        <ol className="mt-8 list-decimal space-y-4 pl-6 text-left text-base leading-relaxed text-[#f5e7c8] sm:text-lg">
+          <li>「スタート」ボタンを押して挑戦を開始します。</li>
+          <li>表示された麻雀のアガリ形と条件を確認します。</li>
+          <li>3つの選択肢から正しい点数を選びます。</li>
+          <li>選択肢を押すと回答が確定し、次の問題へ進みます。</li>
+          <li>同じ流れで全10問に回答します。</li>
+          <li>10問終了後に、正解数・回答時間・ランクを確認します。</li>
+        </ol>
+
+        <p className="mt-6 text-center text-sm text-[#d6bb88]">
+          正確さと回答の速さを意識して、高いスコアを目指しましょう。
+        </p>
+
+        <div className="modal-action justify-center">
+          <button
+            type="button"
+            className="min-w-40 cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-8 py-3 text-lg font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f]"
+            onClick={onClose}
+          >
+            閉じる
+          </button>
+        </div>
+      </section>
+    </dialog>
+  )
+}

--- a/frontend/src/features/top/components/TopActions.tsx
+++ b/frontend/src/features/top/components/TopActions.tsx
@@ -1,6 +1,10 @@
 import styles from './TopActions.module.css'
 
-export function TopActions() {
+type TopActionsProps = {
+  onOpenHowTo: () => void
+}
+
+export function TopActions({ onOpenHowTo }: TopActionsProps) {
   return (
     <nav
       aria-label="トップ画面メニュー"
@@ -16,12 +20,12 @@ export function TopActions() {
       <button
         type="button"
         className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.22em] text-[#063b2b] sm:min-h-24 sm:text-5xl`}
+        onClick={onOpenHowTo}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>
           遊び方
         </span>
       </button>
-
       <button
         type="button"
         className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.18em] text-[#063b2b] sm:min-h-24 sm:text-5xl`}

--- a/frontend/src/features/top/components/TopPage.tsx
+++ b/frontend/src/features/top/components/TopPage.tsx
@@ -1,9 +1,20 @@
 import topBackground from '../assets/top-background.webp'
+import { HowToDialog } from './HowToDialog'
 import { MahjongTileDecoration } from './MahjongTileDecoration'
 import { TopActions } from './TopActions'
 import { TopFooter } from './TopFooter'
 
-export function TopPage() {
+type TopPageProps = {
+  isHowToOpen: boolean
+  onOpenHowTo: () => void
+  onCloseHowTo: () => void
+}
+
+export function TopPage({
+  isHowToOpen,
+  onOpenHowTo,
+  onCloseHowTo,
+}: TopPageProps) {
   return (
     <div
       className="relative min-h-svh overflow-hidden bg-cover bg-center font-['Yu_Mincho','Hiragino_Mincho_ProN',serif]"
@@ -32,7 +43,7 @@ export function TopPage() {
             </div>
 
             <div className="w-full max-w-2xl">
-              <TopActions />
+              <TopActions onOpenHowTo={onOpenHowTo} />
             </div>
           </section>
         </main>
@@ -41,6 +52,8 @@ export function TopPage() {
       </div>
 
       <MahjongTileDecoration />
+
+      <HowToDialog isOpen={isHowToOpen} onClose={onCloseHowTo} />
     </div>
   )
 }

--- a/frontend/src/features/top/containers/TopPageContainer.tsx
+++ b/frontend/src/features/top/containers/TopPageContainer.tsx
@@ -1,5 +1,22 @@
+import { useState } from 'react'
 import { TopPage } from '../components/TopPage'
 
 export function TopPageContainer() {
-  return <TopPage />
+  const [isHowToOpen, setIsHowToOpen] = useState(false)
+
+  const handleOpenHowTo = () => {
+    setIsHowToOpen(true)
+  }
+
+  const handleCloseHowTo = () => {
+    setIsHowToOpen(false)
+  }
+
+  return (
+    <TopPage
+      isHowToOpen={isHowToOpen}
+      onCloseHowTo={handleCloseHowTo}
+      onOpenHowTo={handleOpenHowTo}
+    />
+  )
 }


### PR DESCRIPTION
## 概要

トップ画面から開閉できる遊び方ウィンドウを実装しました。

## 対応内容

- 遊び方ウィンドウ用のコンポーネントを作成
- 10問回答するまでの遊び方を表示
- Containerでウィンドウの開閉状態を管理
- 「遊び方」ボタンからウィンドウを開く処理を追加
- 「閉じる」ボタンでウィンドウを閉じる処理を追加
- Escキーでウィンドウを閉じられるように対応
- dialog要素とaria属性を使用

## 動作確認

- [x] 「遊び方」ボタンでウィンドウが開く
- [x] 遊び方の内容が表示される
- [x] 「閉じる」ボタンで閉じる
- [x] Escキーで閉じる
- [x] 閉じた後にもう一度開ける
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run test:run`が成功する
- [x] `npm run build`が成功する
- [x] GitHub Actionsが成功する
- [x] Vercel Previewが成功する

Closes #6