### PR TITLE
得点・ランクウィンドウを表示 (#7)

### DIFF
--- a/frontend/src/features/top/components/ScoreRankDialog.tsx
+++ b/frontend/src/features/top/components/ScoreRankDialog.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef } from 'react'
+
+type ScoreRankDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const rankCriteria = [
+  {
+    rank: 'G',
+    score: '0〜200',
+    description:
+      'ここがスタート地点です。伸びしろだけなら、すでにSSSランクです。',
+  },
+  {
+    rank: 'F',
+    score: '201〜400',
+    description:
+      '正解より先に選択肢と目が合う時期です。解説を読めば着実に伸びます。',
+  },
+  {
+    rank: 'E',
+    score: '401〜600',
+    description:
+      '役と翻は見えてきました。符計算とは、これから仲良くなりましょう。',
+  },
+  {
+    rank: 'D',
+    score: '601〜800',
+    description:
+      '点数表があれば心強い段階です。まずはよく出る形から覚えましょう。',
+  },
+  {
+    rank: 'C',
+    score: '801〜1000',
+    description: '家族麻雀なら、あなたが点数係を引き受けてあげてください。',
+  },
+  {
+    rank: 'B',
+    score: '1001〜1200',
+    description:
+      '基本的な点数計算は身についています。符が増えたときだけ、少し慎重に。',
+  },
+  {
+    rank: 'A',
+    score: '1201〜1400',
+    description:
+      'よく出るアガリ形なら安定しています。珍しい形でも慌てず計算してみましょう。',
+  },
+  {
+    rank: 'S',
+    score: '1401〜1600',
+    description:
+      '仲間内では頼れる点数係です。たまにはほかの人にも計算させてあげましょう。',
+  },
+  {
+    rank: 'SS',
+    score: '1601〜1800',
+    description:
+      'かなりの計算力です。点数表を開くより、あなたに聞く方が早そうです。',
+  },
+  {
+    rank: 'SSS',
+    score: '1801〜',
+    description:
+      '点数申告で卓を止める心配はほぼありません。雀荘でも自信を持ってどうぞ。',
+  },
+] as const
+
+export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+
+    if (!dialog) {
+      return
+    }
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal()
+    }
+
+    if (!isOpen && dialog.open) {
+      dialog.close()
+    }
+  }, [isOpen])
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="score-rank-dialog-title"
+      className="modal backdrop:bg-black/70"
+      onCancel={onClose}
+      onClose={onClose}
+    >
+      <section className="modal-box max-h-[85svh] max-w-4xl overflow-y-auto border-2 border-[#c6a160] bg-[#0b3022] text-[#f1d49e] shadow-2xl">
+        <h2
+          id="score-rank-dialog-title"
+          className="text-center text-3xl font-bold tracking-[0.15em]"
+        >
+          得点・ランク
+        </h2>
+
+        <p className="mt-4 text-center text-[#f5e7c8]">
+          最終得点は、正解数と回答時間によって決まります。
+        </p>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="table">
+            <thead>
+              <tr className="border-[#c6a160] text-[#e8c58d]">
+                <th>ランク</th>
+                <th>スコア</th>
+                <th>習熟度の目安</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {rankCriteria.map(({ rank, score, description }) => (
+                <tr key={rank} className="border-[#c6a160]/40">
+                  <th className="text-xl text-[#f1d49e]">{rank}</th>
+                  <td className="whitespace-nowrap text-[#f5e7c8]">{score}</td>
+                  <td className="min-w-80 text-[#f5e7c8]">{description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-4 text-center text-sm text-[#d6bb88]">
+          ランクと説明は、本サービスのスコアをもとにした習熟度の目安です。
+        </p>
+
+        <div className="modal-action justify-center">
+          <button
+            type="button"
+            className="min-w-40 cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-8 py-3 text-lg font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f]"
+            onClick={onClose}
+          >
+            閉じる
+          </button>
+        </div>
+      </section>
+    </dialog>
+  )
+}

--- a/frontend/src/features/top/components/TopActions.tsx
+++ b/frontend/src/features/top/components/TopActions.tsx
@@ -2,9 +2,10 @@ import styles from './TopActions.module.css'
 
 type TopActionsProps = {
   onOpenHowTo: () => void
+  onOpenScoreRank: () => void
 }
 
-export function TopActions({ onOpenHowTo }: TopActionsProps) {
+export function TopActions({ onOpenHowTo, onOpenScoreRank }: TopActionsProps) {
   return (
     <nav
       aria-label="トップ画面メニュー"
@@ -29,6 +30,7 @@ export function TopActions({ onOpenHowTo }: TopActionsProps) {
       <button
         type="button"
         className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.18em] text-[#063b2b] sm:min-h-24 sm:text-5xl`}
+        onClick={onOpenScoreRank}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>
           得点・ランク

--- a/frontend/src/features/top/components/TopPage.tsx
+++ b/frontend/src/features/top/components/TopPage.tsx
@@ -3,17 +3,23 @@ import { HowToDialog } from './HowToDialog'
 import { MahjongTileDecoration } from './MahjongTileDecoration'
 import { TopActions } from './TopActions'
 import { TopFooter } from './TopFooter'
+import { ScoreRankDialog } from './ScoreRankDialog'
 
 type TopPageProps = {
   isHowToOpen: boolean
+  isScoreRankOpen: boolean
   onOpenHowTo: () => void
   onCloseHowTo: () => void
+  onOpenScoreRank: () => void
+  onCloseScoreRank: () => void
 }
-
 export function TopPage({
   isHowToOpen,
+  isScoreRankOpen,
   onOpenHowTo,
   onCloseHowTo,
+  onOpenScoreRank,
+  onCloseScoreRank,
 }: TopPageProps) {
   return (
     <div
@@ -21,7 +27,6 @@ export function TopPage({
       style={{ backgroundImage: `url(${topBackground})` }}
     >
       <div aria-hidden="true" className="absolute inset-0 bg-black/20" />
-
       <div className="relative z-20 flex min-h-svh flex-col">
         <main className="flex flex-1 items-center justify-center px-4 py-12 sm:px-6">
           <section className="flex w-full max-w-4xl -translate-y-6 flex-col items-center text-center">
@@ -43,7 +48,10 @@ export function TopPage({
             </div>
 
             <div className="w-full max-w-2xl">
-              <TopActions onOpenHowTo={onOpenHowTo} />
+              <TopActions
+                onOpenHowTo={onOpenHowTo}
+                onOpenScoreRank={onOpenScoreRank}
+              />
             </div>
           </section>
         </main>
@@ -54,6 +62,8 @@ export function TopPage({
       <MahjongTileDecoration />
 
       <HowToDialog isOpen={isHowToOpen} onClose={onCloseHowTo} />
+
+      <ScoreRankDialog isOpen={isScoreRankOpen} onClose={onCloseScoreRank} />
     </div>
   )
 }

--- a/frontend/src/features/top/containers/TopPageContainer.tsx
+++ b/frontend/src/features/top/containers/TopPageContainer.tsx
@@ -3,6 +3,7 @@ import { TopPage } from '../components/TopPage'
 
 export function TopPageContainer() {
   const [isHowToOpen, setIsHowToOpen] = useState(false)
+  const [isScoreRankOpen, setIsScoreRankOpen] = useState(false)
 
   const handleOpenHowTo = () => {
     setIsHowToOpen(true)
@@ -12,11 +13,22 @@ export function TopPageContainer() {
     setIsHowToOpen(false)
   }
 
+  const handleOpenScoreRank = () => {
+    setIsScoreRankOpen(true)
+  }
+
+  const handleCloseScoreRank = () => {
+    setIsScoreRankOpen(false)
+  }
+
   return (
     <TopPage
       isHowToOpen={isHowToOpen}
+      isScoreRankOpen={isScoreRankOpen}
       onCloseHowTo={handleCloseHowTo}
+      onCloseScoreRank={handleCloseScoreRank}
       onOpenHowTo={handleOpenHowTo}
+      onOpenScoreRank={handleOpenScoreRank}
     />
   )
 }


### PR DESCRIPTION
## 概要

トップ画面から開閉できる得点・ランクウィンドウを実装しました。

## 対応内容

- 得点・ランクウィンドウ用のコンポーネントを作成
- G〜SSSのスコア基準を表示
- 各ランクの習熟度説明を表示
- Containerでウィンドウの開閉状態を管理
- 「得点・ランク」ボタンからウィンドウを開く処理を追加
- 「閉じる」ボタンでウィンドウを閉じる処理を追加
- Escキーでウィンドウを閉じられるように対応
- dialog要素とaria属性を使用

## 動作確認

- [x] 「得点・ランク」ボタンでウィンドウが開く
- [x] G〜SSSの10段階が表示される
- [x] スコア基準が表示される
- [x] 各ランクの習熟度説明が表示される
- [x] 「閉じる」ボタンで閉じる
- [x] Escキーで閉じる
- [x] 「遊び方」ウィンドウも引き続き開閉できる
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run test:run`が成功する
- [x] `npm run build`が成功する
- [x] GitHub Actionsが成功する
- [x] Vercel Previewが成功する

Closes #7