### PR TITLE
3つの選択肢から点数を回答できるようにする (#11)

### DIFF
--- a/frontend/src/features/quiz/components/AnswerChoices.test.tsx
+++ b/frontend/src/features/quiz/components/AnswerChoices.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '../../../test/test-utils'
+import { AnswerChoices } from './AnswerChoices'
+
+const ronChoices = ['3,900点', '5,200点', '8,000点'] as const
+
+describe('AnswerChoices', () => {
+  it('3つの点数選択肢をボタンとして表示する', () => {
+    render(
+      <AnswerChoices
+        choices={ronChoices}
+        selectedAnswer={null}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+
+    for (const choice of ronChoices) {
+      expect(screen.getByRole('button', { name: choice })).toBeInTheDocument()
+    }
+  })
+
+  it('選択した回答をonSelectで通知する', async () => {
+    const onSelect = vi.fn()
+    const { user } = render(
+      <AnswerChoices
+        choices={ronChoices}
+        selectedAnswer={null}
+        onSelect={onSelect}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: '5,200点' }))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(onSelect).toHaveBeenCalledWith('5,200点')
+  })
+
+  it('選択中の回答を押下状態で表示する', () => {
+    render(
+      <AnswerChoices
+        choices={ronChoices}
+        selectedAnswer="5,200点"
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: '5,200点' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: '3,900点' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  })
+
+  it('ツモの点数表記を表示できる', () => {
+    const tsumoChoices = [
+      '1,000点 / 2,000点',
+      '2,000点 / 4,000点',
+      '3,000点 / 6,000点',
+    ] as const
+
+    render(
+      <AnswerChoices
+        choices={tsumoChoices}
+        selectedAnswer={null}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: '2,000点 / 4,000点' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/quiz/components/AnswerChoices.tsx
+++ b/frontend/src/features/quiz/components/AnswerChoices.tsx
@@ -1,0 +1,39 @@
+type AnswerChoicesProps = {
+  readonly choices: readonly [string, string, string]
+  readonly selectedAnswer: string | null
+  readonly onSelect: (answer: string) => void
+}
+
+export function AnswerChoices({
+  choices,
+  selectedAnswer,
+  onSelect,
+}: AnswerChoicesProps) {
+  return (
+    <div
+      role="group"
+      aria-label="点数の選択肢"
+      className="grid w-full gap-3 sm:grid-cols-3"
+    >
+      {choices.map((choice, index) => {
+        const isSelected = choice === selectedAnswer
+
+        return (
+          <button
+            key={`${choice}-${index}`}
+            type="button"
+            aria-pressed={isSelected}
+            className={`min-h-16 cursor-pointer rounded border-2 px-4 py-3 text-lg font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] ${
+              isSelected
+                ? 'border-[#f1d49e] bg-[#1b4b36] text-[#f1d49e] ring-2 ring-[#d4ae6b]'
+                : 'border-[#c6a160] bg-[#f2e5c8] text-[#063b2b] hover:bg-[#f8efd9]'
+            }`}
+            onClick={() => onSelect(choice)}
+          >
+            <span className="whitespace-normal break-words">{choice}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -1,4 +1,5 @@
 export { questions } from './data/question'
+export { AnswerChoices } from './components/AnswerChoices'
 export { MahjongTile } from './components/MahjongTile'
 export { WinningHand } from './components/WinningHand'
 export { QUESTIONS_PER_PATTERN, selectQuestions } from './logic/selectQuestions'


### PR DESCRIPTION
## 概要

問題ごとに表示される3つの点数から、ユーザーが回答を選択できるようにしました。

## 対応内容

- `AnswerChoices`コンポーネントを作成
- 3つの点数選択肢をボタンとして表示
- 選択した回答を`onSelect`で親コンポーネントへ通知
- 選択中のボタンを視覚的に区別
- `aria-pressed`でボタンの選択状態を表現
- ロンの点数表記に対応
- ツモの点数表記に対応
- `index.ts`の公開APIへ追加
- コンポーネントテストを追加

## 動作確認

- [x] 3つの点数選択肢が表示される
- [x] 選択肢がボタンとして実装されている
- [x] 選択した回答を取得できる
- [x] 選択中のボタンを判別できる
- [x] ロンの点数を表示できる
- [x] ツモの点数を表示できる
- [x] `npm run test:run`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #11