### PR TITLE
選択時に回答を確定して次の問題へ進める (#12)

### DIFF
--- a/frontend/src/features/quiz/hooks/useQuizProgress.test.ts
+++ b/frontend/src/features/quiz/hooks/useQuizProgress.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { act, renderHook } from '../../../test/test-utils'
+import { questions } from '../data/question'
+import { useQuizProgress } from './useQuizProgress'
+
+describe('useQuizProgress', () => {
+  it('選択した回答を回答履歴へ保存する', () => {
+    const { result } = renderHook(() => useQuizProgress(questions))
+    const firstQuestion = questions[0]
+
+    act(() => {
+      result.current.confirmAnswer(firstQuestion.correctAnswer)
+    })
+
+    expect(result.current.answers).toEqual([
+      {
+        questionId: firstQuestion.id,
+        selectedAnswer: firstQuestion.correctAnswer,
+      },
+    ])
+  })
+
+  it('回答確定時には正誤判定結果を保存しない', () => {
+    const { result } = renderHook(() => useQuizProgress(questions))
+    const firstQuestion = questions[0]
+    const incorrectAnswer = firstQuestion.choices.find(
+      (choice) => choice !== firstQuestion.correctAnswer,
+    )
+
+    act(() => {
+      result.current.confirmAnswer(incorrectAnswer!)
+    })
+
+    expect(result.current.answers[0]).toEqual({
+      questionId: firstQuestion.id,
+      selectedAnswer: incorrectAnswer,
+    })
+    expect(result.current.answers[0]).not.toHaveProperty('isCorrect')
+  })
+
+  it('回答確定後に次の問題へ進む', () => {
+    const { result } = renderHook(() => useQuizProgress(questions))
+
+    act(() => {
+      result.current.confirmAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.currentQuestionIndex).toBe(1)
+    expect(result.current.currentQuestion?.id).toBe(questions[1].id)
+  })
+
+  it('同じ問題を連続して確定しても1件だけ保存する', () => {
+    const { result } = renderHook(() => useQuizProgress(questions))
+    const confirmFirstAnswer = result.current.confirmAnswer
+
+    act(() => {
+      confirmFirstAnswer(questions[0].choices[0])
+      confirmFirstAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.answers).toHaveLength(1)
+    expect(result.current.currentQuestionIndex).toBe(1)
+  })
+
+  it('10問目の回答確定後に完了状態になる', () => {
+    const { result } = renderHook(() => useQuizProgress(questions))
+
+    for (const question of questions) {
+      act(() => {
+        result.current.confirmAnswer(question.choices[0])
+      })
+    }
+
+    expect(result.current.answers).toHaveLength(10)
+    expect(result.current.status).toBe('completed')
+    expect(result.current.isCompleted).toBe(true)
+    expect(result.current.currentQuestion).toBeNull()
+  })
+})

--- a/frontend/src/features/quiz/hooks/useQuizProgress.ts
+++ b/frontend/src/features/quiz/hooks/useQuizProgress.ts
@@ -1,0 +1,89 @@
+import { useCallback, useReducer } from 'react'
+
+import type { QuizProgressState } from '../types/answer'
+import type { Question } from '../types/question'
+
+type ConfirmAnswerAction = {
+  readonly type: 'confirmAnswer'
+  readonly question: Question
+  readonly selectedAnswer: string
+  readonly totalQuestions: number
+}
+
+function createInitialState(totalQuestions: number): QuizProgressState {
+  return {
+    currentQuestionIndex: 0,
+    answers: [],
+    status: totalQuestions === 0 ? 'completed' : 'answering',
+  }
+}
+
+function quizProgressReducer(
+  state: QuizProgressState,
+  action: ConfirmAnswerAction,
+): QuizProgressState {
+  if (state.status === 'completed') {
+    return state
+  }
+
+  const isAlreadyAnswered = state.answers.some(
+    (answer) => answer.questionId === action.question.id,
+  )
+
+  if (isAlreadyAnswered) {
+    return state
+  }
+
+  const answers = [
+    ...state.answers,
+    {
+      questionId: action.question.id,
+      selectedAnswer: action.selectedAnswer,
+    },
+  ]
+  const isLastQuestion = state.currentQuestionIndex >= action.totalQuestions - 1
+
+  return {
+    currentQuestionIndex: isLastQuestion
+      ? state.currentQuestionIndex
+      : state.currentQuestionIndex + 1,
+    answers,
+    status: isLastQuestion ? 'completed' : 'answering',
+  }
+}
+
+export function useQuizProgress(questions: readonly Question[]) {
+  const [state, dispatch] = useReducer(
+    quizProgressReducer,
+    questions.length,
+    createInitialState,
+  )
+
+  const currentQuestion =
+    state.status === 'answering'
+      ? (questions[state.currentQuestionIndex] ?? null)
+      : null
+
+  const confirmAnswer = useCallback(
+    (selectedAnswer: string) => {
+      if (currentQuestion === null) {
+        return
+      }
+
+      dispatch({
+        type: 'confirmAnswer',
+        question: currentQuestion,
+        selectedAnswer,
+        totalQuestions: questions.length,
+      })
+    },
+    [currentQuestion, questions.length],
+  )
+
+  return {
+    ...state,
+    currentQuestion,
+    isCompleted: state.status === 'completed',
+    confirmAnswer,
+  }
+}

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -2,6 +2,7 @@ export { questions } from './data/question'
 export { AnswerChoices } from './components/AnswerChoices'
 export { MahjongTile } from './components/MahjongTile'
 export { WinningHand } from './components/WinningHand'
+export { useQuizProgress } from './hooks/useQuizProgress'
 export { QUESTIONS_PER_PATTERN, selectQuestions } from './logic/selectQuestions'
 
 export type {
@@ -17,3 +18,9 @@ export type {
   TileCode,
   WinType,
 } from './types/question'
+
+export type {
+  AnswerRecord,
+  QuizProgressState,
+  QuizStatus,
+} from './types/answer'

--- a/frontend/src/features/quiz/types/answer.ts
+++ b/frontend/src/features/quiz/types/answer.ts
@@ -1,0 +1,12 @@
+export type AnswerRecord = {
+  readonly questionId: string
+  readonly selectedAnswer: string
+}
+
+export type QuizStatus = 'answering' | 'completed'
+
+export type QuizProgressState = {
+  readonly currentQuestionIndex: number
+  readonly answers: readonly AnswerRecord[]
+  readonly status: QuizStatus
+}


### PR DESCRIPTION
## 概要

選択肢を選んだ時点で回答を履歴へ保存し、次の問題へ進む機能を実装しました。

## 対応内容

- 回答履歴の型を定義
- クイズの進行状態を管理する`useQuizProgress`を作成
- 選択した問題IDと回答を履歴へ保存
- 同じ問題への重複回答を防止
- 回答確定後に次の問題へ移動
- 10問目の回答後に完了状態へ移行
- 完了状態を結果画面への切り替えに利用できるように設定
- 回答確定時には正誤判定を行わず、後続の採点処理へ分離
- 回答進行処理のテストを追加

## 動作確認

- [x] 選択した回答を履歴へ保存できる
- [x] 回答履歴には問題IDと選択した回答だけが保存される
- [x] 同じ問題へ重複回答できない
- [x] 回答確定後に次の問題へ進む
- [x] 10問目の回答後に完了状態になる
- [x] 全27テストが成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #12