### PR TITLE
点数計算問題を全10問出題 (#9)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "daisyui": "^5.7.16",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-router-dom": "^7.18.2",
         "tailwindcss": "^4.3.3"
       },
       "devDependencies": {
@@ -2308,6 +2309,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3721,6 +3735,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3805,6 +3857,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "daisyui": "^5.7.16",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-router-dom": "^7.18.2",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,29 @@
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from './test/test-utils'
+import App from './App'
+
+describe('App routing', () => {
+  it('トップ画面のスタートから問題画面へ遷移する', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'スタート' }))
+
+    expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
+  })
+
+  it('/quizを直接開いて問題画面を表示できる', () => {
+    render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,20 @@
+import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
+import { QuizPageContainer } from './features/quiz'
 import { TopPageContainer } from './features/top/containers/TopPageContainer'
 
 function App() {
-  return <TopPageContainer />
+  const navigate = useNavigate()
+
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={<TopPageContainer onStart={() => navigate('/quiz')} />}
+      />
+      <Route path="/quiz" element={<QuizPageContainer />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
 }
 
 export default App

--- a/frontend/src/features/quiz/components/MahjongTile.tsx
+++ b/frontend/src/features/quiz/components/MahjongTile.tsx
@@ -11,7 +11,7 @@ export function MahjongTile({ tile, className = '' }: MahjongTileProps) {
     <img
       src={getMahjongTileImagePath(tile)}
       alt={`${tile}の麻雀牌`}
-      className={`block h-auto w-10 shrink-0 select-none sm:w-12 md:w-14 ${className}`}
+      className={`block h-auto w-10 shrink-0 select-none rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] sm:w-12 md:w-14 ${className}`}
       draggable="false"
     />
   )

--- a/frontend/src/features/quiz/components/QuizPage.test.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '../../../test/test-utils'
+import { questions } from '../data/question'
+import { QuizPage } from './QuizPage'
+
+describe('QuizPage', () => {
+  it('現在の問題番号・条件・アガリ形・3つの選択肢を表示する', () => {
+    render(
+      <QuizPage
+        question={questions[0]}
+        currentQuestionNumber={1}
+        totalQuestions={10}
+        onAnswer={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('progressbar', { name: '問題の進捗' }),
+    ).toHaveAttribute('value', '1')
+    expect(screen.getByText('子')).toBeInTheDocument()
+    expect(screen.getByText('ロン')).toBeInTheDocument()
+    expect(screen.getByText('5翻')).toBeInTheDocument()
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  it('選択した回答をonAnswerで通知する', async () => {
+    const onAnswer = vi.fn()
+    const { user } = render(
+      <QuizPage
+        question={questions[0]}
+        currentQuestionNumber={1}
+        totalQuestions={10}
+        onAnswer={onAnswer}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: questions[0].choices[0] }),
+    )
+
+    expect(onAnswer).toHaveBeenCalledOnce()
+    expect(onAnswer).toHaveBeenCalledWith(questions[0].choices[0])
+  })
+
+  it('問題に副露がある場合は副露牌を表示する', () => {
+    render(
+      <QuizPage
+        question={questions[5]}
+        currentQuestionNumber={6}
+        totalQuestions={10}
+        onAnswer={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('group', { name: '副露（ポン）' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/quiz/components/QuizPage.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.tsx
@@ -1,0 +1,98 @@
+import type { Question } from '../types/question'
+import { AnswerChoices } from './AnswerChoices'
+import { WinningHand } from './WinningHand'
+
+type QuizPageProps = {
+  readonly question: Question
+  readonly currentQuestionNumber: number
+  readonly totalQuestions: number
+  readonly onAnswer: (answer: string) => void
+}
+
+export function QuizPage({
+  question,
+  currentQuestionNumber,
+  totalQuestions,
+  onAnswer,
+}: QuizPageProps) {
+  const playerLabel = question.condition.player === 'dealer' ? '親' : '子'
+  const winTypeLabel = question.condition.winType === 'ron' ? 'ロン' : 'ツモ'
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[#031a14] px-2 py-4 text-[#f1d49e] sm:px-4 sm:py-6">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.7),transparent_58%),linear-gradient(135deg,rgba(198,161,96,0.08),transparent_45%)]"
+      />
+      <div className="relative mx-auto w-full max-w-none rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:p-8">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+          <header className="text-center">
+            <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">QUESTION</p>
+            <h1 className="mt-1 text-3xl font-semibold">
+              {currentQuestionNumber} / {totalQuestions}
+            </h1>
+            <progress
+              aria-label="問題の進捗"
+              value={currentQuestionNumber}
+              max={totalQuestions}
+              className="progress mt-4 h-3 w-full bg-[#02140f] [&::-moz-progress-bar]:bg-[#d4ae6b] [&::-webkit-progress-value]:bg-[#d4ae6b]"
+            />
+          </header>
+
+          <section
+            aria-labelledby="question-condition-heading"
+            className="rounded border border-[#c6a160] bg-black/20 p-5"
+          >
+            <h2
+              id="question-condition-heading"
+              className="text-center text-xl font-semibold"
+            >
+              問題の条件
+            </h2>
+            <dl className="mt-4 flex flex-wrap justify-center gap-x-8 gap-y-3 text-lg">
+              <div className="flex gap-2">
+                <dt className="text-[#d4ae6b]">家</dt>
+                <dd>{playerLabel}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="text-[#d4ae6b]">アガリ方</dt>
+                <dd>{winTypeLabel}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="text-[#d4ae6b]">翻数</dt>
+                <dd>{question.han}翻</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section
+            aria-labelledby="winning-hand-heading"
+            className="rounded border border-[#c6a160] bg-black/20 p-5"
+          >
+            <h2
+              id="winning-hand-heading"
+              className="mb-5 text-center text-xl font-semibold"
+            >
+              アガリ形
+            </h2>
+            <WinningHand hand={question.hand} />
+          </section>
+
+          <section aria-labelledby="answer-heading">
+            <h2
+              id="answer-heading"
+              className="mb-4 text-center text-xl font-semibold"
+            >
+              点数を選択してください
+            </h2>
+            <AnswerChoices
+              choices={question.choices}
+              selectedAnswer={null}
+              onSelect={onAnswer}
+            />
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/features/quiz/containers/QuizPageContainer.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { QuizPage } from '../components/QuizPage'
+import { questions } from '../data/question'
+import { useQuizProgress } from '../hooks/useQuizProgress'
+import { selectQuestions } from '../logic/selectQuestions'
+
+export function QuizPageContainer() {
+  const [quizQuestions] = useState(() => selectQuestions(questions))
+  const {
+    answers,
+    confirmAnswer,
+    currentQuestion,
+    currentQuestionIndex,
+    isCompleted,
+  } = useQuizProgress(quizQuestions)
+
+  if (isCompleted) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#05251d] px-4 text-[#f1d49e]">
+        <div className="text-center">
+          <h1 className="text-3xl font-semibold">10問の回答が完了しました</h1>
+          <p className="mt-4 text-lg">{answers.length}問に回答済みです。</p>
+        </div>
+      </main>
+    )
+  }
+
+  if (currentQuestion === null) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#05251d] text-[#f1d49e]">
+        <p>問題を読み込めませんでした。</p>
+      </main>
+    )
+  }
+
+  return (
+    <QuizPage
+      question={currentQuestion}
+      currentQuestionNumber={currentQuestionIndex + 1}
+      totalQuestions={quizQuestions.length}
+      onAnswer={confirmAnswer}
+    />
+  )
+}

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -2,6 +2,7 @@ export { questions } from './data/question'
 export { AnswerChoices } from './components/AnswerChoices'
 export { MahjongTile } from './components/MahjongTile'
 export { WinningHand } from './components/WinningHand'
+export { QuizPageContainer } from './containers/QuizPageContainer'
 export { useQuizProgress } from './hooks/useQuizProgress'
 export { QUESTIONS_PER_PATTERN, selectQuestions } from './logic/selectQuestions'
 

--- a/frontend/src/features/top/components/MahjongTileDecoration.tsx
+++ b/frontend/src/features/top/components/MahjongTileDecoration.tsx
@@ -12,17 +12,17 @@ export function MahjongTileDecoration() {
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute right-36 bottom-96 z-10 hidden origin-bottom-right -rotate-10 items-end brightness-50 md:flex"
+      className="pointer-events-none absolute right-36 bottom-96 z-10 hidden origin-bottom-right -rotate-10 items-end opacity-80 md:flex"
     >
       {tileNames.map((tileName, index) => (
         <div
           key={tileName}
-          className="relative -ml-3 aspect-[3/4] w-[clamp(6rem,7vw,9rem)] overflow-hidden rounded-[12%] border-2 border-[#a9854e] bg-[#efe4cb] shadow-[inset_0_0_0_3px_rgba(127,91,43,0.18)] drop-shadow-[0_8px_6px_rgba(0,0,0,0.6)] first:ml-0"
+          className="relative -ml-3 aspect-[3/4] w-[clamp(6rem,7vw,9rem)] overflow-hidden rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] first:ml-0"
           style={{ transform: `translateY(${index * -3}px)` }}
         >
           <img
             alt=""
-            className="size-full"
+            className="size-full object-contain"
             draggable="false"
             src={`/assets/mahjong/${tileName}.svg`}
           />

--- a/frontend/src/features/top/components/TopActions.tsx
+++ b/frontend/src/features/top/components/TopActions.tsx
@@ -1,11 +1,16 @@
 import styles from './TopActions.module.css'
 
 type TopActionsProps = {
+  onStart: () => void
   onOpenHowTo: () => void
   onOpenScoreRank: () => void
 }
 
-export function TopActions({ onOpenHowTo, onOpenScoreRank }: TopActionsProps) {
+export function TopActions({
+  onStart,
+  onOpenHowTo,
+  onOpenScoreRank,
+}: TopActionsProps) {
   return (
     <nav
       aria-label="トップ画面メニュー"
@@ -14,6 +19,7 @@ export function TopActions({ onOpenHowTo, onOpenScoreRank }: TopActionsProps) {
       <button
         type="button"
         className={`${styles.ornateButton} ${styles.primaryButton} min-h-32 w-full cursor-pointer px-8 py-4 text-5xl font-semibold tracking-[0.28em] text-[#f1d49e] sm:min-h-40 sm:text-6xl`}
+        onClick={onStart}
       >
         <span className={styles.label}>スタート</span>
       </button>

--- a/frontend/src/features/top/components/TopPage.tsx
+++ b/frontend/src/features/top/components/TopPage.tsx
@@ -8,6 +8,7 @@ import { ScoreRankDialog } from './ScoreRankDialog'
 type TopPageProps = {
   isHowToOpen: boolean
   isScoreRankOpen: boolean
+  onStart: () => void
   onOpenHowTo: () => void
   onCloseHowTo: () => void
   onOpenScoreRank: () => void
@@ -16,6 +17,7 @@ type TopPageProps = {
 export function TopPage({
   isHowToOpen,
   isScoreRankOpen,
+  onStart,
   onOpenHowTo,
   onCloseHowTo,
   onOpenScoreRank,
@@ -49,6 +51,7 @@ export function TopPage({
 
             <div className="w-full max-w-2xl">
               <TopActions
+                onStart={onStart}
                 onOpenHowTo={onOpenHowTo}
                 onOpenScoreRank={onOpenScoreRank}
               />

--- a/frontend/src/features/top/containers/TopPageContainer.tsx
+++ b/frontend/src/features/top/containers/TopPageContainer.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
 import { TopPage } from '../components/TopPage'
 
-export function TopPageContainer() {
+type TopPageContainerProps = {
+  readonly onStart: () => void
+}
+
+export function TopPageContainer({ onStart }: TopPageContainerProps) {
   const [isHowToOpen, setIsHowToOpen] = useState(false)
   const [isScoreRankOpen, setIsScoreRankOpen] = useState(false)
 
@@ -25,6 +29,7 @@ export function TopPageContainer() {
     <TopPage
       isHowToOpen={isHowToOpen}
       isScoreRankOpen={isScoreRankOpen}
+      onStart={onStart}
       onCloseHowTo={handleCloseHowTo}
       onCloseScoreRank={handleCloseScoreRank}
       onOpenHowTo={handleOpenHowTo}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

点数計算問題を全10問出題し、トップ画面から問題画面へ遷移して回答できるようにしました。

## 対応内容

- React Routerを導入
- `/quiz`に問題画面を追加
- トップ画面の「スタート」ボタンから問題画面へ遷移
- 現在の問題番号と進捗ゲージを表示
- 問題の条件・アガリ形・3つの選択肢を表示
- 回答確定後に次の問題を表示
- 10問目の回答後に完了画面を表示
- 麻雀牌の視認性を改善
- VercelでSPAのURLを直接表示できるように設定
- 問題画面とルーティングのテストを追加

## 動作確認

- [x] `npm run format:check`が成功する
- [x] `npm run test:run`が成功する（10ファイル・32テスト）
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する
- [x] トップ画面から問題画面へ遷移できる
- [x] 全10問に回答できる
- [x] 問題ごとに条件・アガリ形・選択肢が表示される

Closes #9