### PR TITLE
回答時間をミリ秒単位で計測 (#13)

### DIFF
--- a/frontend/src/features/quiz/hooks/useQuizProgress.test.ts
+++ b/frontend/src/features/quiz/hooks/useQuizProgress.test.ts
@@ -5,6 +5,36 @@ import { questions } from '../data/question'
 import { useQuizProgress } from './useQuizProgress'
 
 describe('useQuizProgress', () => {
+  it('問題開始時に時間計測を開始する', () => {
+    const now = () => 1_000
+    const { result } = renderHook(() =>
+      useQuizProgress(questions, {
+        now,
+      }),
+    )
+
+    expect(result.current.startedAtMs).toBe(1_000)
+    expect(result.current.elapsedTimeMs).toBe(0)
+  })
+
+  it('回答確定時にミリ秒単位の経過時間を更新する', () => {
+    let currentTimeMs = 1_000
+    const now = () => currentTimeMs
+    const { result } = renderHook(() =>
+      useQuizProgress(questions, {
+        now,
+      }),
+    )
+
+    currentTimeMs = 1_123.6
+
+    act(() => {
+      result.current.confirmAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.elapsedTimeMs).toBe(124)
+  })
+
   it('選択した回答を回答履歴へ保存する', () => {
     const { result } = renderHook(() => useQuizProgress(questions))
     const firstQuestion = questions[0]
@@ -64,17 +94,72 @@ describe('useQuizProgress', () => {
   })
 
   it('10問目の回答確定後に完了状態になる', () => {
-    const { result } = renderHook(() => useQuizProgress(questions))
+    let currentTimeMs = 1_000
+    const now = () => currentTimeMs
+    const { result } = renderHook(() =>
+      useQuizProgress(questions, {
+        now,
+      }),
+    )
 
-    for (const question of questions) {
+    questions.forEach((question, index) => {
+      currentTimeMs = 1_100 + index * 100
+
       act(() => {
         result.current.confirmAnswer(question.choices[0])
       })
-    }
+    })
 
     expect(result.current.answers).toHaveLength(10)
     expect(result.current.status).toBe('completed')
     expect(result.current.isCompleted).toBe(true)
     expect(result.current.currentQuestion).toBeNull()
+    expect(result.current.elapsedTimeMs).toBe(1_000)
+
+    currentTimeMs = 5_000
+
+    act(() => {
+      result.current.confirmAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.elapsedTimeMs).toBe(1_000)
+  })
+
+  it('再挑戦時に進行状況と計測時間をリセットする', () => {
+    let currentTimeMs = 1_000
+    const now = () => currentTimeMs
+    const { result } = renderHook(() =>
+      useQuizProgress(questions, {
+        now,
+      }),
+    )
+
+    currentTimeMs = 1_250
+
+    act(() => {
+      result.current.confirmAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.elapsedTimeMs).toBe(250)
+
+    currentTimeMs = 2_000
+
+    act(() => {
+      result.current.resetQuiz()
+    })
+
+    expect(result.current.answers).toHaveLength(0)
+    expect(result.current.currentQuestionIndex).toBe(0)
+    expect(result.current.status).toBe('answering')
+    expect(result.current.startedAtMs).toBe(2_000)
+    expect(result.current.elapsedTimeMs).toBe(0)
+
+    currentTimeMs = 2_125
+
+    act(() => {
+      result.current.confirmAnswer(questions[0].choices[0])
+    })
+
+    expect(result.current.elapsedTimeMs).toBe(125)
   })
 })

--- a/frontend/src/features/quiz/hooks/useQuizProgress.ts
+++ b/frontend/src/features/quiz/hooks/useQuizProgress.ts
@@ -8,20 +8,59 @@ type ConfirmAnswerAction = {
   readonly question: Question
   readonly selectedAnswer: string
   readonly totalQuestions: number
+  readonly confirmedAtMs: number
 }
 
-function createInitialState(totalQuestions: number): QuizProgressState {
+type ResetQuizAction = {
+  readonly type: 'resetQuiz'
+  readonly totalQuestions: number
+  readonly startedAtMs: number
+}
+
+type QuizProgressAction = ConfirmAnswerAction | ResetQuizAction
+
+type InitialStateArguments = {
+  readonly totalQuestions: number
+  readonly now: () => number
+}
+
+type UseQuizProgressOptions = {
+  readonly now?: () => number
+}
+
+const getCurrentTimeMs = () => performance.now()
+
+function createInitialState({
+  totalQuestions,
+  now,
+}: InitialStateArguments): QuizProgressState {
+  const hasQuestions = totalQuestions > 0
+
   return {
     currentQuestionIndex: 0,
     answers: [],
-    status: totalQuestions === 0 ? 'completed' : 'answering',
+    status: hasQuestions ? 'answering' : 'completed',
+    startedAtMs: hasQuestions ? now() : null,
+    elapsedTimeMs: 0,
   }
 }
 
 function quizProgressReducer(
   state: QuizProgressState,
-  action: ConfirmAnswerAction,
+  action: QuizProgressAction,
 ): QuizProgressState {
+  if (action.type === 'resetQuiz') {
+    const hasQuestions = action.totalQuestions > 0
+
+    return {
+      currentQuestionIndex: 0,
+      answers: [],
+      status: hasQuestions ? 'answering' : 'completed',
+      startedAtMs: hasQuestions ? action.startedAtMs : null,
+      elapsedTimeMs: 0,
+    }
+  }
+
   if (state.status === 'completed') {
     return state
   }
@@ -42,6 +81,10 @@ function quizProgressReducer(
     },
   ]
   const isLastQuestion = state.currentQuestionIndex >= action.totalQuestions - 1
+  const elapsedTimeMs =
+    state.startedAtMs === null
+      ? 0
+      : Math.max(0, Math.round(action.confirmedAtMs - state.startedAtMs))
 
   return {
     currentQuestionIndex: isLastQuestion
@@ -49,13 +92,22 @@ function quizProgressReducer(
       : state.currentQuestionIndex + 1,
     answers,
     status: isLastQuestion ? 'completed' : 'answering',
+    startedAtMs: state.startedAtMs,
+    elapsedTimeMs,
   }
 }
 
-export function useQuizProgress(questions: readonly Question[]) {
+export function useQuizProgress(
+  questions: readonly Question[],
+  options: UseQuizProgressOptions = {},
+) {
+  const now = options.now ?? getCurrentTimeMs
   const [state, dispatch] = useReducer(
     quizProgressReducer,
-    questions.length,
+    {
+      totalQuestions: questions.length,
+      now,
+    },
     createInitialState,
   )
 
@@ -75,15 +127,25 @@ export function useQuizProgress(questions: readonly Question[]) {
         question: currentQuestion,
         selectedAnswer,
         totalQuestions: questions.length,
+        confirmedAtMs: now(),
       })
     },
-    [currentQuestion, questions.length],
+    [currentQuestion, now, questions.length],
   )
+
+  const resetQuiz = useCallback(() => {
+    dispatch({
+      type: 'resetQuiz',
+      totalQuestions: questions.length,
+      startedAtMs: now(),
+    })
+  }, [now, questions.length])
 
   return {
     ...state,
     currentQuestion,
     isCompleted: state.status === 'completed',
     confirmAnswer,
+    resetQuiz,
   }
 }

--- a/frontend/src/features/quiz/types/answer.ts
+++ b/frontend/src/features/quiz/types/answer.ts
@@ -9,4 +9,6 @@ export type QuizProgressState = {
   readonly currentQuestionIndex: number
   readonly answers: readonly AnswerRecord[]
   readonly status: QuizStatus
+  readonly startedAtMs: number | null
+  readonly elapsedTimeMs: number
 }


### PR DESCRIPTION
## 概要

10問の回答時間をミリ秒単位で計測できるようにしました。

## 対応内容

- 問題開始時に時間計測を開始
- `performance.now()`を使用して経過時間を取得
- 回答確定時に経過時間を更新
- 10問目の回答確定時に計測を終了
- 再挑戦用のリセット処理を追加
- 回答履歴・進捗・計測時間をまとめてリセット
- 時間計測に関するテストを追加

## 動作確認

- [x] 問題開始時に計測が開始される
- [x] 経過時間をミリ秒単位で取得できる
- [x] 10問目の回答確定後に計測値が変化しない
- [x] 再挑戦時に計測時間が0へ戻る
- [x] `npm run test:run`が成功する（10ファイル・35テスト）
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #13