### PR TITLE
挑戦を途中で終了する機能を実装 (#18)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -26,4 +26,17 @@ describe('App routing', () => {
 
     expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
   })
+
+  it('問題画面のやめるボタンから確認なしでトップ画面へ戻る', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'やめる' }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,10 @@ function App() {
         path="/"
         element={<TopPageContainer onStart={() => navigate('/quiz')} />}
       />
-      <Route path="/quiz" element={<QuizPageContainer />} />
+      <Route
+        path="/quiz"
+        element={<QuizPageContainer onQuit={() => navigate('/')} />}
+      />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/frontend/src/features/quiz/components/QuizPage.test.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.test.tsx
@@ -12,6 +12,7 @@ describe('QuizPage', () => {
         currentQuestionNumber={1}
         totalQuestions={10}
         onAnswer={vi.fn()}
+        onQuit={vi.fn()}
       />,
     )
 
@@ -22,7 +23,8 @@ describe('QuizPage', () => {
     expect(screen.getByText('子')).toBeInTheDocument()
     expect(screen.getByText('ロン')).toBeInTheDocument()
     expect(screen.getByText('5翻')).toBeInTheDocument()
-    expect(screen.getAllByRole('button')).toHaveLength(3)
+    expect(screen.getAllByRole('button')).toHaveLength(4)
+    expect(screen.getByRole('button', { name: 'やめる' })).toBeInTheDocument()
   })
 
   it('選択した回答をonAnswerで通知する', async () => {
@@ -33,6 +35,7 @@ describe('QuizPage', () => {
         currentQuestionNumber={1}
         totalQuestions={10}
         onAnswer={onAnswer}
+        onQuit={vi.fn()}
       />,
     )
 
@@ -51,11 +54,29 @@ describe('QuizPage', () => {
         currentQuestionNumber={6}
         totalQuestions={10}
         onAnswer={vi.fn()}
+        onQuit={vi.fn()}
       />,
     )
 
     expect(
       screen.getByRole('group', { name: '副露（ポン）' }),
     ).toBeInTheDocument()
+  })
+
+  it('やめるボタンからonQuitを通知する', async () => {
+    const onQuit = vi.fn()
+    const { user } = render(
+      <QuizPage
+        question={questions[0]}
+        currentQuestionNumber={1}
+        totalQuestions={10}
+        onAnswer={vi.fn()}
+        onQuit={onQuit}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'やめる' }))
+
+    expect(onQuit).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/quiz/components/QuizPage.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.tsx
@@ -7,6 +7,7 @@ type QuizPageProps = {
   readonly currentQuestionNumber: number
   readonly totalQuestions: number
   readonly onAnswer: (answer: string) => void
+  readonly onQuit: () => void
 }
 
 export function QuizPage({
@@ -14,6 +15,7 @@ export function QuizPage({
   currentQuestionNumber,
   totalQuestions,
   onAnswer,
+  onQuit,
 }: QuizPageProps) {
   const playerLabel = question.condition.player === 'dealer' ? '親' : '子'
   const winTypeLabel = question.condition.winType === 'ron' ? 'ロン' : 'ツモ'
@@ -26,7 +28,16 @@ export function QuizPage({
       />
       <div className="relative mx-auto w-full max-w-none rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:p-8">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
-          <header className="text-center">
+          <header className="relative text-center">
+            <div className="mb-4 flex justify-end sm:absolute sm:top-0 sm:right-0 sm:mb-0">
+              <button
+                type="button"
+                className="cursor-pointer rounded border border-[#c6a160] bg-[#031a14]/70 px-4 py-2 text-sm font-semibold tracking-[0.12em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+                onClick={onQuit}
+              >
+                やめる
+              </button>
+            </div>
             <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">QUESTION</p>
             <h1 className="mt-1 text-3xl font-semibold">
               {currentQuestionNumber} / {totalQuestions}

--- a/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, within } from '../../../test/test-utils'
+import { QuizPageContainer } from './QuizPageContainer'
+
+describe('QuizPageContainer', () => {
+  it('やめると回答状況を初期化してonQuitを通知する', async () => {
+    const onQuit = vi.fn()
+    const { user } = render(<QuizPageContainer onQuit={onQuit} />)
+    const answerChoices = screen.getByRole('group', {
+      name: '点数の選択肢',
+    })
+
+    await user.click(within(answerChoices).getAllByRole('button')[0])
+
+    expect(screen.getByRole('heading', { name: '2 / 10' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'やめる' }))
+
+    expect(onQuit).toHaveBeenCalledOnce()
+    expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/quiz/containers/QuizPageContainer.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.tsx
@@ -4,7 +4,11 @@ import { questions } from '../data/question'
 import { useQuizProgress } from '../hooks/useQuizProgress'
 import { selectQuestions } from '../logic/selectQuestions'
 
-export function QuizPageContainer() {
+type QuizPageContainerProps = {
+  readonly onQuit: () => void
+}
+
+export function QuizPageContainer({ onQuit }: QuizPageContainerProps) {
   const [quizQuestions] = useState(() => selectQuestions(questions))
   const {
     answers,
@@ -12,7 +16,13 @@ export function QuizPageContainer() {
     currentQuestion,
     currentQuestionIndex,
     isCompleted,
+    resetQuiz,
   } = useQuizProgress(quizQuestions)
+
+  const handleQuit = () => {
+    resetQuiz()
+    onQuit()
+  }
 
   if (isCompleted) {
     return (
@@ -39,6 +49,7 @@ export function QuizPageContainer() {
       currentQuestionNumber={currentQuestionIndex + 1}
       totalQuestions={quizQuestions.length}
       onAnswer={confirmAnswer}
+      onQuit={handleQuit}
     />
   )
 }


### PR DESCRIPTION
## 概要

問題への挑戦を途中で終了し、トップ画面へ戻れるようにしました。

## 対応内容

- 問題画面に「やめる」ボタンを追加
- 確認ダイアログを表示せずトップ画面へ遷移
- 終了時に回答状況を初期化
- 終了時に回答時間をリセット
- 表示・状態初期化・画面遷移のテストを追加

## 動作確認

- [x] 問題画面に「やめる」ボタンが表示される
- [x] 「やめる」を押すと確認なしでトップ画面へ戻る
- [x] 回答途中で終了すると進行状況が初期化される
- [x] 終了時に計測時間が初期化される
- [x] `npm run test:run`が成功する（11ファイル・38テスト）
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #18