### PR TITLE
スコアに応じたランクと習熟度を表示 (#15)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -39,4 +39,38 @@ describe('App routing', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument()
   })
+
+  it('10問完了後に結果画面へ遷移する', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    for (let index = 0; index < 10; index += 1) {
+      await user.click(
+        screen
+          .getByRole('group', { name: '点数の選択肢' })
+          .querySelector('button')!,
+      )
+    }
+
+    expect(
+      await screen.findByRole('heading', { name: '結果' }),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('ランク')).toBeInTheDocument()
+    expect(screen.getByText('スコア')).toBeInTheDocument()
+    expect(screen.getByText('正解数')).toBeInTheDocument()
+    expect(screen.getByText('回答時間')).toBeInTheDocument()
+  })
+
+  it('結果データなしで/resultを開くとトップ画面へ戻る', () => {
+    render(
+      <MemoryRouter initialEntries={['/result']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,49 @@
+import { useCallback, useState } from 'react'
 import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
-import { QuizPageContainer } from './features/quiz'
+import { QuizPageContainer, type QuizResult } from './features/quiz'
+import { ResultPageContainer } from './features/result'
 import { TopPageContainer } from './features/top/containers/TopPageContainer'
 
 function App() {
   const navigate = useNavigate()
+  const [quizResult, setQuizResult] = useState<QuizResult | null>(null)
+
+  const handleStart = useCallback(() => {
+    setQuizResult(null)
+    navigate('/quiz')
+  }, [navigate])
+
+  const handleQuit = useCallback(() => {
+    setQuizResult(null)
+    navigate('/')
+  }, [navigate])
+
+  const handleComplete = useCallback(
+    (result: QuizResult) => {
+      setQuizResult(result)
+      navigate('/result')
+    },
+    [navigate],
+  )
 
   return (
     <Routes>
-      <Route
-        path="/"
-        element={<TopPageContainer onStart={() => navigate('/quiz')} />}
-      />
+      <Route path="/" element={<TopPageContainer onStart={handleStart} />} />
       <Route
         path="/quiz"
-        element={<QuizPageContainer onQuit={() => navigate('/')} />}
+        element={
+          <QuizPageContainer onQuit={handleQuit} onComplete={handleComplete} />
+        }
+      />
+      <Route
+        path="/result"
+        element={
+          quizResult === null ? (
+            <Navigate to="/" replace />
+          ) : (
+            <ResultPageContainer result={quizResult} />
+          )
+        }
       />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { render, screen, within } from '../../../test/test-utils'
+import { render, screen, waitFor, within } from '../../../test/test-utils'
 import { QuizPageContainer } from './QuizPageContainer'
 
 describe('QuizPageContainer', () => {
   it('やめると回答状況を初期化してonQuitを通知する', async () => {
     const onQuit = vi.fn()
-    const { user } = render(<QuizPageContainer onQuit={onQuit} />)
+    const { user } = render(
+      <QuizPageContainer onQuit={onQuit} onComplete={vi.fn()} />,
+    )
     const answerChoices = screen.getByRole('group', {
       name: '点数の選択肢',
     })
@@ -19,5 +21,32 @@ describe('QuizPageContainer', () => {
 
     expect(onQuit).toHaveBeenCalledOnce()
     expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
+  })
+
+  it('10問完了時にスコア・正解数・回答時間をonCompleteで通知する', async () => {
+    const onComplete = vi.fn()
+    const { user } = render(
+      <QuizPageContainer onQuit={vi.fn()} onComplete={onComplete} />,
+    )
+
+    for (let index = 0; index < 10; index += 1) {
+      const answerChoices = screen.getByRole('group', {
+        name: '点数の選択肢',
+      })
+
+      await user.click(within(answerChoices).getAllByRole('button')[0])
+    }
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledOnce()
+    })
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correctCount: expect.any(Number),
+        totalScore: expect.any(Number),
+        totalQuestions: 10,
+        elapsedTimeMs: expect.any(Number),
+      }),
+    )
   })
 })

--- a/frontend/src/features/quiz/containers/QuizPageContainer.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import type { QuizResult } from '../types/score'
 import { QuizPage } from '../components/QuizPage'
 import { questions } from '../data/question'
 import { useQuizProgress } from '../hooks/useQuizProgress'
@@ -7,9 +8,13 @@ import { selectQuestions } from '../logic/selectQuestions'
 
 type QuizPageContainerProps = {
   readonly onQuit: () => void
+  readonly onComplete: (result: QuizResult) => void
 }
 
-export function QuizPageContainer({ onQuit }: QuizPageContainerProps) {
+export function QuizPageContainer({
+  onQuit,
+  onComplete,
+}: QuizPageContainerProps) {
   const [quizQuestions] = useState(() => selectQuestions(questions))
   const {
     answers,
@@ -20,6 +25,24 @@ export function QuizPageContainer({ onQuit }: QuizPageContainerProps) {
     isCompleted,
     resetQuiz,
   } = useQuizProgress(quizQuestions)
+  const result = useMemo<QuizResult>(
+    () => ({
+      ...calculateScore({
+        questions: quizQuestions,
+        answers,
+        elapsedTimeMs,
+      }),
+      totalQuestions: quizQuestions.length,
+      elapsedTimeMs,
+    }),
+    [answers, elapsedTimeMs, quizQuestions],
+  )
+
+  useEffect(() => {
+    if (isCompleted) {
+      onComplete(result)
+    }
+  }, [isCompleted, onComplete, result])
 
   const handleQuit = () => {
     resetQuiz()
@@ -27,21 +50,9 @@ export function QuizPageContainer({ onQuit }: QuizPageContainerProps) {
   }
 
   if (isCompleted) {
-    const score = calculateScore({
-      questions: quizQuestions,
-      answers,
-      elapsedTimeMs,
-    })
-
     return (
       <main className="flex min-h-screen items-center justify-center bg-[#05251d] px-4 text-[#f1d49e]">
-        <div className="text-center">
-          <h1 className="text-3xl font-semibold">10問の回答が完了しました</h1>
-          <p className="mt-4 text-lg">{score.correctCount}問正解</p>
-          <p className="mt-2 text-2xl font-semibold">
-            スコア：{score.totalScore.toLocaleString()}点
-          </p>
-        </div>
+        <p>結果を集計しています。</p>
       </main>
     )
   }

--- a/frontend/src/features/quiz/data/rankCriteria.ts
+++ b/frontend/src/features/quiz/data/rankCriteria.ts
@@ -1,0 +1,83 @@
+import type { RankCriterion } from '../types/rank'
+
+export const rankCriteria = [
+  {
+    rank: 'G',
+    minScore: 0,
+    maxScore: 200,
+    scoreLabel: '0〜200',
+    description:
+      'ここがスタート地点です。伸びしろだけなら、すでにSSSランクです。',
+  },
+  {
+    rank: 'F',
+    minScore: 201,
+    maxScore: 400,
+    scoreLabel: '201〜400',
+    description:
+      '正解より先に選択肢と目が合う時期です。解説を読めば着実に伸びます。',
+  },
+  {
+    rank: 'E',
+    minScore: 401,
+    maxScore: 600,
+    scoreLabel: '401〜600',
+    description:
+      '役と翻は見えてきました。符計算とは、これから仲良くなりましょう。',
+  },
+  {
+    rank: 'D',
+    minScore: 601,
+    maxScore: 800,
+    scoreLabel: '601〜800',
+    description:
+      '点数表があれば心強い段階です。まずはよく出る形から覚えましょう。',
+  },
+  {
+    rank: 'C',
+    minScore: 801,
+    maxScore: 1_000,
+    scoreLabel: '801〜1000',
+    description: '家族麻雀なら、あなたが点数係を引き受けてあげてください。',
+  },
+  {
+    rank: 'B',
+    minScore: 1_001,
+    maxScore: 1_200,
+    scoreLabel: '1001〜1200',
+    description:
+      '基本的な点数計算は身についています。符が増えたときだけ、少し慎重に。',
+  },
+  {
+    rank: 'A',
+    minScore: 1_201,
+    maxScore: 1_400,
+    scoreLabel: '1201〜1400',
+    description:
+      'よく出るアガリ形なら安定しています。珍しい形でも慌てず計算してみましょう。',
+  },
+  {
+    rank: 'S',
+    minScore: 1_401,
+    maxScore: 1_600,
+    scoreLabel: '1401〜1600',
+    description:
+      '仲間内では頼れる点数係です。たまにはほかの人にも計算させてあげましょう。',
+  },
+  {
+    rank: 'SS',
+    minScore: 1_601,
+    maxScore: 1_800,
+    scoreLabel: '1601〜1800',
+    description:
+      'かなりの計算力です。点数表を開くより、あなたに聞く方が早そうです。',
+  },
+  {
+    rank: 'SSS',
+    minScore: 1_801,
+    maxScore: null,
+    scoreLabel: '1801〜',
+    description:
+      '点数申告で卓を止める心配はほぼありません。雀荘でも自信を持ってどうぞ。',
+  },
+] as const satisfies readonly RankCriterion[]

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -1,4 +1,5 @@
 export { questions } from './data/question'
+export { rankCriteria } from './data/rankCriteria'
 export { AnswerChoices } from './components/AnswerChoices'
 export { MahjongTile } from './components/MahjongTile'
 export { WinningHand } from './components/WinningHand'
@@ -10,6 +11,7 @@ export {
   TIME_BONUS_BASE_SCORE,
   TIME_BONUS_REFERENCE_MS,
 } from './logic/calculateScore'
+export { determineRank } from './logic/determineRank'
 export { QUESTIONS_PER_PATTERN, selectQuestions } from './logic/selectQuestions'
 
 export type {
@@ -31,4 +33,5 @@ export type {
   QuizProgressState,
   QuizStatus,
 } from './types/answer'
-export type { ScoreResult } from './types/score'
+export type { Rank, RankCriterion } from './types/rank'
+export type { QuizResult, ScoreResult } from './types/score'

--- a/frontend/src/features/quiz/logic/determineRank.test.ts
+++ b/frontend/src/features/quiz/logic/determineRank.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { rankCriteria } from '../data/rankCriteria'
+import { determineRank } from './determineRank'
+
+describe('rankCriteria', () => {
+  it('GからSSSまで境界値が途切れずに定義されている', () => {
+    expect(rankCriteria.map(({ rank }) => rank)).toEqual([
+      'G',
+      'F',
+      'E',
+      'D',
+      'C',
+      'B',
+      'A',
+      'S',
+      'SS',
+      'SSS',
+    ])
+
+    rankCriteria.slice(1).forEach((criterion, index) => {
+      expect(criterion.minScore).toBe(rankCriteria[index].maxScore! + 1)
+    })
+
+    expect(rankCriteria.at(-1)?.maxScore).toBeNull()
+  })
+})
+
+describe('determineRank', () => {
+  it.each([
+    [0, 'G'],
+    [200, 'G'],
+    [201, 'F'],
+    [400, 'F'],
+    [401, 'E'],
+    [600, 'E'],
+    [601, 'D'],
+    [800, 'D'],
+    [801, 'C'],
+    [1_000, 'C'],
+    [1_001, 'B'],
+    [1_200, 'B'],
+    [1_201, 'A'],
+    [1_400, 'A'],
+    [1_401, 'S'],
+    [1_600, 'S'],
+    [1_601, 'SS'],
+    [1_800, 'SS'],
+    [1_801, 'SSS'],
+    [100_000, 'SSS'],
+  ] as const)('スコア%sをランク%sと判定する', (score, expectedRank) => {
+    expect(determineRank(score).rank).toBe(expectedRank)
+  })
+
+  it('負のスコアとNaNはランクGと判定する', () => {
+    expect(determineRank(-1).rank).toBe('G')
+    expect(determineRank(Number.NaN).rank).toBe('G')
+  })
+})

--- a/frontend/src/features/quiz/logic/determineRank.ts
+++ b/frontend/src/features/quiz/logic/determineRank.ts
@@ -1,0 +1,18 @@
+import { rankCriteria } from '../data/rankCriteria'
+import type { RankCriterion } from '../types/rank'
+
+export function determineRank(score: number): RankCriterion {
+  if (Number.isNaN(score) || score < 0) {
+    return rankCriteria[0]
+  }
+
+  for (let index = rankCriteria.length - 1; index >= 0; index -= 1) {
+    const criterion = rankCriteria[index]
+
+    if (score >= criterion.minScore) {
+      return criterion
+    }
+  }
+
+  return rankCriteria[0]
+}

--- a/frontend/src/features/quiz/types/rank.ts
+++ b/frontend/src/features/quiz/types/rank.ts
@@ -1,0 +1,9 @@
+export type Rank = 'G' | 'F' | 'E' | 'D' | 'C' | 'B' | 'A' | 'S' | 'SS' | 'SSS'
+
+export type RankCriterion = {
+  readonly rank: Rank
+  readonly minScore: number
+  readonly maxScore: number | null
+  readonly scoreLabel: string
+  readonly description: string
+}

--- a/frontend/src/features/quiz/types/score.ts
+++ b/frontend/src/features/quiz/types/score.ts
@@ -4,3 +4,8 @@ export type ScoreResult = {
   readonly timeBonus: number
   readonly totalScore: number
 }
+
+export type QuizResult = ScoreResult & {
+  readonly totalQuestions: number
+  readonly elapsedTimeMs: number
+}

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../../test/test-utils'
+import type { QuizResult, RankCriterion } from '../../quiz'
+import { ResultPage } from './ResultPage'
+
+const result: QuizResult = {
+  correctCount: 8,
+  correctScore: 800,
+  timeBonus: 700,
+  totalScore: 1_500,
+  totalQuestions: 10,
+  elapsedTimeMs: 45_678,
+}
+
+const rankCriterion: RankCriterion = {
+  rank: 'S',
+  minScore: 1_401,
+  maxScore: 1_600,
+  scoreLabel: '1401〜1600',
+  description: 'Sランクの習熟度説明です。',
+}
+
+describe('ResultPage', () => {
+  it('スコア・ランク・習熟度・正解数・回答時間を表示する', () => {
+    render(<ResultPage result={result} rankCriterion={rankCriterion} />)
+
+    expect(screen.getByRole('heading', { name: '結果' })).toBeInTheDocument()
+    expect(screen.getByLabelText('ランク')).toHaveTextContent('S')
+    expect(screen.getByText('Sランクの習熟度説明です。')).toBeInTheDocument()
+    expect(screen.getByText('1,500点')).toBeInTheDocument()
+    expect(screen.getByText('8 / 10問')).toBeInTheDocument()
+    expect(screen.getByText('45.678秒')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -1,0 +1,62 @@
+import type { QuizResult, RankCriterion } from '../../quiz'
+
+type ResultPageProps = {
+  readonly result: QuizResult
+  readonly rankCriterion: RankCriterion
+}
+
+function formatElapsedTime(elapsedTimeMs: number): string {
+  return `${(elapsedTimeMs / 1_000).toFixed(3)}秒`
+}
+
+export function ResultPage({ result, rankCriterion }: ResultPageProps) {
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#031a14] px-4 py-8 text-[#f1d49e] sm:px-6">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.75),transparent_60%),linear-gradient(135deg,rgba(198,161,96,0.1),transparent_45%)]"
+      />
+
+      <section className="relative w-full max-w-4xl rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 px-5 py-8 text-center shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:px-10 sm:py-12">
+        <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">RESULT</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[0.15em] sm:text-4xl">
+          結果
+        </h1>
+
+        <div className="mt-8">
+          <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">RANK</p>
+          <p
+            aria-label="ランク"
+            className="mt-2 text-7xl font-bold text-[#f1d49e] drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-8xl"
+          >
+            {rankCriterion.rank}
+          </p>
+          <p className="mx-auto mt-5 max-w-2xl leading-relaxed text-[#f5e7c8] sm:text-lg">
+            {rankCriterion.description}
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-3">
+          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
+            <p className="text-sm text-[#d4ae6b]">スコア</p>
+            <p className="mt-2 text-3xl font-semibold">
+              {result.totalScore.toLocaleString()}点
+            </p>
+          </div>
+          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
+            <p className="text-sm text-[#d4ae6b]">正解数</p>
+            <p className="mt-2 text-3xl font-semibold">
+              {result.correctCount} / {result.totalQuestions}問
+            </p>
+          </div>
+          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
+            <p className="text-sm text-[#d4ae6b]">回答時間</p>
+            <p className="mt-2 text-3xl font-semibold">
+              {formatElapsedTime(result.elapsedTimeMs)}
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/features/result/containers/ResultPageContainer.tsx
+++ b/frontend/src/features/result/containers/ResultPageContainer.tsx
@@ -1,0 +1,12 @@
+import { determineRank, type QuizResult } from '../../quiz'
+import { ResultPage } from '../components/ResultPage'
+
+type ResultPageContainerProps = {
+  readonly result: QuizResult
+}
+
+export function ResultPageContainer({ result }: ResultPageContainerProps) {
+  const rankCriterion = determineRank(result.totalScore)
+
+  return <ResultPage result={result} rankCriterion={rankCriterion} />
+}

--- a/frontend/src/features/result/index.ts
+++ b/frontend/src/features/result/index.ts
@@ -1,0 +1,2 @@
+export { ResultPage } from './components/ResultPage'
+export { ResultPageContainer } from './containers/ResultPageContainer'

--- a/frontend/src/features/top/components/ScoreRankDialog.tsx
+++ b/frontend/src/features/top/components/ScoreRankDialog.tsx
@@ -1,71 +1,10 @@
 import { useEffect, useRef } from 'react'
+import { rankCriteria } from '../../quiz'
 
 type ScoreRankDialogProps = {
   isOpen: boolean
   onClose: () => void
 }
-
-const rankCriteria = [
-  {
-    rank: 'G',
-    score: '0〜200',
-    description:
-      'ここがスタート地点です。伸びしろだけなら、すでにSSSランクです。',
-  },
-  {
-    rank: 'F',
-    score: '201〜400',
-    description:
-      '正解より先に選択肢と目が合う時期です。解説を読めば着実に伸びます。',
-  },
-  {
-    rank: 'E',
-    score: '401〜600',
-    description:
-      '役と翻は見えてきました。符計算とは、これから仲良くなりましょう。',
-  },
-  {
-    rank: 'D',
-    score: '601〜800',
-    description:
-      '点数表があれば心強い段階です。まずはよく出る形から覚えましょう。',
-  },
-  {
-    rank: 'C',
-    score: '801〜1000',
-    description: '家族麻雀なら、あなたが点数係を引き受けてあげてください。',
-  },
-  {
-    rank: 'B',
-    score: '1001〜1200',
-    description:
-      '基本的な点数計算は身についています。符が増えたときだけ、少し慎重に。',
-  },
-  {
-    rank: 'A',
-    score: '1201〜1400',
-    description:
-      'よく出るアガリ形なら安定しています。珍しい形でも慌てず計算してみましょう。',
-  },
-  {
-    rank: 'S',
-    score: '1401〜1600',
-    description:
-      '仲間内では頼れる点数係です。たまにはほかの人にも計算させてあげましょう。',
-  },
-  {
-    rank: 'SS',
-    score: '1601〜1800',
-    description:
-      'かなりの計算力です。点数表を開くより、あなたに聞く方が早そうです。',
-  },
-  {
-    rank: 'SSS',
-    score: '1801〜',
-    description:
-      '点数申告で卓を止める心配はほぼありません。雀荘でも自信を持ってどうぞ。',
-  },
-] as const
 
 export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
@@ -117,10 +56,12 @@ export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
             </thead>
 
             <tbody>
-              {rankCriteria.map(({ rank, score, description }) => (
+              {rankCriteria.map(({ rank, scoreLabel, description }) => (
                 <tr key={rank} className="border-[#c6a160]/40">
                   <th className="text-xl text-[#f1d49e]">{rank}</th>
-                  <td className="whitespace-nowrap text-[#f5e7c8]">{score}</td>
+                  <td className="whitespace-nowrap text-[#f5e7c8]">
+                    {scoreLabel}
+                  </td>
                   <td className="min-w-80 text-[#f5e7c8]">{description}</td>
                 </tr>
               ))}


### PR DESCRIPTION
## 概要

スコアからG〜SSSのランクを判定し、結果画面へスコア・ランク・習熟度などを表示できるようにしました。

## 対応内容

- G〜SSSのランク境界値を共通データとして定義
- スコアからランクを判定するロジックを追加
- `/result`に結果画面を追加
- 結果画面にスコアとランクを表示
- ランクに応じた習熟度の説明を表示
- 正解数と回答時間を表示
- 10問完了後に結果画面へ遷移
- 結果データなしで`/result`を開いた場合はトップ画面へ遷移
- 「得点・ランク」ダイアログとランク境界データを共通化
- ランク判定・結果表示・画面遷移のテストを追加

## 動作確認

- [x] 各ランクの下限・上限で正しく判定される
- [x] 1801点以上はSSSランクになる
- [x] 結果画面にスコアとランクが表示される
- [x] ランクに対応する習熟度が表示される
- [x] 正解数と回答時間が表示される
- [x] 10問完了後に`/result`へ遷移する
- [x] `npm run test:run`が成功する（14ファイル・70テスト）
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #15