### PR TITLE
10問分の正誤と解説を確認できるようにする (#16)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -62,15 +62,33 @@ describe('App routing', () => {
     expect(screen.getByText('スコア')).toBeInTheDocument()
     expect(screen.getByText('正解数')).toBeInTheDocument()
     expect(screen.getByText('回答時間')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '10問の解説を見る' }))
+
+    expect(
+      await screen.findByRole('heading', { name: '10問の解説' }),
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('article')).toHaveLength(10)
+
+    await user.click(screen.getAllByRole('button', { name: '結果に戻る' })[0])
+
+    expect(
+      await screen.findByRole('heading', { name: '結果' }),
+    ).toBeInTheDocument()
   })
 
-  it('結果データなしで/resultを開くとトップ画面へ戻る', () => {
-    render(
-      <MemoryRouter initialEntries={['/result']}>
-        <App />
-      </MemoryRouter>,
-    )
+  it.each(['/result', '/review'])(
+    '結果データなしで%sを開くとトップ画面へ戻る',
+    (path) => {
+      render(
+        <MemoryRouter initialEntries={[path]}>
+          <App />
+        </MemoryRouter>,
+      )
 
-    expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument()
-  })
+      expect(
+        screen.getByRole('button', { name: 'スタート' }),
+      ).toBeInTheDocument()
+    },
+  )
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useState } from 'react'
 import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
 import { QuizPageContainer, type QuizResult } from './features/quiz'
-import { ResultPageContainer } from './features/result'
+import {
+  AnswerReviewPageContainer,
+  ResultPageContainer,
+} from './features/result'
 import { TopPageContainer } from './features/top/containers/TopPageContainer'
 
 function App() {
@@ -41,7 +44,23 @@ function App() {
           quizResult === null ? (
             <Navigate to="/" replace />
           ) : (
-            <ResultPageContainer result={quizResult} />
+            <ResultPageContainer
+              result={quizResult}
+              onReview={() => navigate('/review')}
+            />
+          )
+        }
+      />
+      <Route
+        path="/review"
+        element={
+          quizResult === null ? (
+            <Navigate to="/" replace />
+          ) : (
+            <AnswerReviewPageContainer
+              result={quizResult}
+              onBack={() => navigate('/result')}
+            />
           )
         }
       />

--- a/frontend/src/features/quiz/containers/QuizPageContainer.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.tsx
@@ -34,6 +34,8 @@ export function QuizPageContainer({
       }),
       totalQuestions: quizQuestions.length,
       elapsedTimeMs,
+      questions: quizQuestions,
+      answers,
     }),
     [answers, elapsedTimeMs, quizQuestions],
   )

--- a/frontend/src/features/quiz/data/question.test.ts
+++ b/frontend/src/features/quiz/data/question.test.ts
@@ -23,6 +23,17 @@ describe('questions', () => {
     }
   })
 
+  it('役・翻・符・ドラ・解説を管理できる', () => {
+    for (const question of questions) {
+      const yakuHan = question.yaku.reduce((total, yaku) => total + yaku.han, 0)
+
+      expect(question.yaku.length).toBeGreaterThan(0)
+      expect(yakuHan + question.dora).toBe(question.han)
+      expect(question.dora).toBeGreaterThanOrEqual(0)
+      expect(question.explanation.length).toBeGreaterThan(0)
+    }
+  })
+
   it('パターンAとパターンBを識別できる', () => {
     const patternAQuestion = questions.find(
       (question) => question.pattern === 'A',

--- a/frontend/src/features/quiz/data/question.ts
+++ b/frontend/src/features/quiz/data/question.ts
@@ -29,9 +29,12 @@ export const questions = [
     },
     choices: ['3,900点', '5,200点', '8,000点'],
     correctAnswer: '8,000点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 5,
     fu: null,
-    explanation: '子のロン和了で5翻のため、満貫の8,000点です。',
+    dora: 4,
+    explanation:
+      'リーチ1翻とドラ4枚で計5翻です。子のロン和了は満貫の8,000点になります。',
   },
   {
     id: 'question-002',
@@ -61,9 +64,12 @@ export const questions = [
     },
     choices: ['8,000点', '12,000点', '18,000点'],
     correctAnswer: '12,000点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 5,
     fu: null,
-    explanation: '親のロン和了で5翻のため、満貫の12,000点です。',
+    dora: 4,
+    explanation:
+      'リーチ1翻とドラ4枚で計5翻です。親のロン和了は満貫の12,000点になります。',
   },
   {
     id: 'question-003',
@@ -93,9 +99,12 @@ export const questions = [
     },
     choices: ['8,000点', '12,000点', '16,000点'],
     correctAnswer: '12,000点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 6,
     fu: null,
-    explanation: '子のロン和了で6翻のため、跳満の12,000点です。',
+    dora: 5,
+    explanation:
+      'リーチ1翻とドラ5枚で計6翻です。子のロン和了は跳満の12,000点になります。',
   },
   {
     id: 'question-004',
@@ -125,9 +134,12 @@ export const questions = [
     },
     choices: ['12,000点', '18,000点', '24,000点'],
     correctAnswer: '18,000点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 6,
     fu: null,
-    explanation: '親のロン和了で6翻のため、跳満の18,000点です。',
+    dora: 5,
+    explanation:
+      'リーチ1翻とドラ5枚で計6翻です。親のロン和了は跳満の18,000点になります。',
   },
   {
     id: 'question-005',
@@ -157,9 +169,12 @@ export const questions = [
     },
     choices: ['12,000点', '16,000点', '24,000点'],
     correctAnswer: '16,000点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 8,
     fu: null,
-    explanation: '子のロン和了で8翻のため、倍満の16,000点です。',
+    dora: 7,
+    explanation:
+      'リーチ1翻とドラ7枚で計8翻です。子のロン和了は倍満の16,000点になります。',
   },
   {
     id: 'question-006',
@@ -191,9 +206,12 @@ export const questions = [
     },
     choices: ['3,900点', '5,200点', '7,700点'],
     correctAnswer: '5,200点',
+    yaku: [{ name: '役牌 中', han: 1 }],
     han: 3,
     fu: 40,
-    explanation: '子のロン和了で40符3翻のため、5,200点です。',
+    dora: 2,
+    explanation:
+      '役牌 中1翻とドラ2枚で計3翻です。子のロン和了で40符3翻のため、5,200点になります。',
   },
   {
     id: 'question-007',
@@ -225,9 +243,12 @@ export const questions = [
     },
     choices: ['2,000点', '2,600点', '3,200点'],
     correctAnswer: '2,600点',
+    yaku: [{ name: '役牌 場風 東', han: 1 }],
     han: 2,
     fu: 40,
-    explanation: '子のロン和了で40符2翻のため、2,600点です。',
+    dora: 1,
+    explanation:
+      '役牌 場風 東1翻とドラ1枚で計2翻です。子のロン和了で40符2翻のため、2,600点になります。',
   },
   {
     id: 'question-008',
@@ -257,9 +278,12 @@ export const questions = [
     },
     choices: ['2,600点', '3,900点', '5,200点'],
     correctAnswer: '3,900点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 3,
     fu: 30,
-    explanation: '子のロン和了で30符3翻のため、3,900点です。',
+    dora: 2,
+    explanation:
+      'リーチ1翻とドラ2枚で計3翻です。子のロン和了で30符3翻のため、3,900点になります。',
   },
   {
     id: 'question-009',
@@ -289,9 +313,12 @@ export const questions = [
     },
     choices: ['3,900点', '5,800点', '7,700点'],
     correctAnswer: '5,800点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 3,
     fu: 30,
-    explanation: '親のロン和了で30符3翻のため、5,800点です。',
+    dora: 2,
+    explanation:
+      'リーチ1翻とドラ2枚で計3翻です。親のロン和了で30符3翻のため、5,800点になります。',
   },
   {
     id: 'question-010',
@@ -321,8 +348,11 @@ export const questions = [
     },
     choices: ['2,600点', '3,200点', '3,900点'],
     correctAnswer: '3,200点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 2,
     fu: 50,
-    explanation: '子のロン和了で50符2翻のため、3,200点です。',
+    dora: 1,
+    explanation:
+      'リーチ1翻とドラ1枚で計2翻です。子のロン和了で50符2翻のため、3,200点になります。',
   },
 ] as const satisfies readonly Question[]

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -26,6 +26,7 @@ export type {
   QuestionPattern,
   TileCode,
   WinType,
+  Yaku,
 } from './types/question'
 
 export type {

--- a/frontend/src/features/quiz/logic/selectQuestions.test.ts
+++ b/frontend/src/features/quiz/logic/selectQuestions.test.ts
@@ -34,7 +34,9 @@ function createQuestion(
     },
     choices: ['3,900点', '5,200点', '8,000点'],
     correctAnswer: '5,200点',
+    yaku: [{ name: 'リーチ', han: 1 }],
     han: 3,
+    dora: 2,
     explanation: 'テスト用の問題です。',
   } as const
 

--- a/frontend/src/features/quiz/types/question.ts
+++ b/frontend/src/features/quiz/types/question.ts
@@ -38,13 +38,20 @@ export type QuestionCondition = {
   readonly winType: WinType
 }
 
+export type Yaku = {
+  readonly name: string
+  readonly han: number
+}
+
 type BaseQuestion = {
   readonly id: string
   readonly hand: QuestionHand
   readonly condition: QuestionCondition
   readonly choices: readonly [string, string, string]
   readonly correctAnswer: string
+  readonly yaku: readonly Yaku[]
   readonly han: number
+  readonly dora: number
   readonly explanation: string
 }
 

--- a/frontend/src/features/quiz/types/score.ts
+++ b/frontend/src/features/quiz/types/score.ts
@@ -1,3 +1,6 @@
+import type { AnswerRecord } from './answer'
+import type { Question } from './question'
+
 export type ScoreResult = {
   readonly correctCount: number
   readonly correctScore: number
@@ -8,4 +11,6 @@ export type ScoreResult = {
 export type QuizResult = ScoreResult & {
   readonly totalQuestions: number
   readonly elapsedTimeMs: number
+  readonly questions: readonly Question[]
+  readonly answers: readonly AnswerRecord[]
 }

--- a/frontend/src/features/result/components/AnswerReviewPage.test.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, within } from '../../../test/test-utils'
+import { questions } from '../../quiz'
+import type { ReviewedQuestion } from '../types/review'
+import { AnswerReviewPage } from './AnswerReviewPage'
+
+const reviewedQuestions: ReviewedQuestion[] = questions.map(
+  (question, index) => ({
+    question,
+    selectedAnswer: index === 0 ? question.correctAnswer : question.choices[0],
+    isCorrect:
+      (index === 0 ? question.correctAnswer : question.choices[0]) ===
+      question.correctAnswer,
+  }),
+)
+
+describe('AnswerReviewPage', () => {
+  it('10問分の正誤・回答・役・翻・符・ドラ・解説を表示する', () => {
+    render(
+      <AnswerReviewPage
+        reviewedQuestions={reviewedQuestions}
+        onBack={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: '10問の解説' }),
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('article')).toHaveLength(10)
+
+    const firstQuestion = screen.getAllByRole('article')[0]
+
+    expect(
+      within(firstQuestion).getByLabelText('問題1の判定'),
+    ).toHaveTextContent('正解')
+    expect(
+      within(firstQuestion).getAllByText(questions[0].correctAnswer),
+    ).toHaveLength(2)
+    expect(within(firstQuestion).getByText('リーチ（1翻）')).toBeInTheDocument()
+    expect(within(firstQuestion).getByText('5翻')).toBeInTheDocument()
+    expect(
+      within(firstQuestion).getByText('計算不要（満貫以上）'),
+    ).toBeInTheDocument()
+    expect(within(firstQuestion).getByText('4枚')).toBeInTheDocument()
+    expect(
+      within(firstQuestion).getByText(questions[0].explanation),
+    ).toBeInTheDocument()
+  })
+
+  it('結果に戻る操作を通知する', async () => {
+    const onBack = vi.fn()
+    const { user } = render(
+      <AnswerReviewPage
+        reviewedQuestions={reviewedQuestions}
+        onBack={onBack}
+      />,
+    )
+
+    await user.click(screen.getAllByRole('button', { name: '結果に戻る' })[0])
+
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/features/result/components/AnswerReviewPage.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.tsx
@@ -1,0 +1,143 @@
+import { WinningHand } from '../../quiz'
+import type { ReviewedQuestion } from '../types/review'
+
+type AnswerReviewPageProps = {
+  readonly reviewedQuestions: readonly ReviewedQuestion[]
+  readonly onBack: () => void
+}
+
+function BackButton({ onBack }: { readonly onBack: () => void }) {
+  return (
+    <button
+      type="button"
+      className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-6 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+      onClick={onBack}
+    >
+      結果に戻る
+    </button>
+  )
+}
+
+export function AnswerReviewPage({
+  reviewedQuestions,
+  onBack,
+}: AnswerReviewPageProps) {
+  return (
+    <main className="relative min-h-screen bg-[#031a14] px-3 py-6 text-[#f1d49e] sm:px-6 sm:py-10">
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.7),transparent_58%),linear-gradient(135deg,rgba(198,161,96,0.08),transparent_45%)]"
+      />
+
+      <div className="relative mx-auto w-full max-w-6xl">
+        <header className="flex flex-col items-center gap-5 text-center sm:flex-row sm:justify-between sm:text-left">
+          <div>
+            <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">REVIEW</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-[0.12em] sm:text-4xl">
+              10問の解説
+            </h1>
+          </div>
+          <BackButton onBack={onBack} />
+        </header>
+
+        <ol className="mt-8 space-y-8">
+          {reviewedQuestions.map(
+            ({ question, selectedAnswer, isCorrect }, index) => {
+              const headingId = `review-question-${index + 1}`
+              const yakuLabel = question.yaku
+                .map((yaku) => `${yaku.name}（${yaku.han}翻）`)
+                .join('、')
+
+              return (
+                <li key={question.id}>
+                  <article
+                    aria-labelledby={headingId}
+                    className="rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_12px_30px_rgba(0,0,0,0.55)] sm:p-8"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <h2 id={headingId} className="text-2xl font-semibold">
+                        問題 {index + 1}
+                      </h2>
+                      <span
+                        aria-label={`問題${index + 1}の判定`}
+                        className={`rounded-full border px-4 py-1 text-sm font-semibold ${
+                          isCorrect
+                            ? 'border-emerald-300 bg-emerald-950/70 text-emerald-200'
+                            : 'border-red-300 bg-red-950/70 text-red-200'
+                        }`}
+                      >
+                        {isCorrect ? '正解' : '不正解'}
+                      </span>
+                    </div>
+
+                    <div className="mt-6 rounded border border-[#c6a160]/70 bg-black/20 p-4 sm:p-5">
+                      <WinningHand hand={question.hand} />
+                    </div>
+
+                    <dl className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                        <dt className="text-sm text-[#d4ae6b]">役</dt>
+                        <dd className="mt-1">{yakuLabel}</dd>
+                      </div>
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                        <dt className="text-sm text-[#d4ae6b]">翻</dt>
+                        <dd className="mt-1">{question.han}翻</dd>
+                      </div>
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                        <dt className="text-sm text-[#d4ae6b]">符</dt>
+                        <dd className="mt-1">
+                          {question.fu === null
+                            ? '計算不要（満貫以上）'
+                            : `${question.fu}符`}
+                        </dd>
+                      </div>
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                        <dt className="text-sm text-[#d4ae6b]">ドラ</dt>
+                        <dd className="mt-1">{question.dora}枚</dd>
+                      </div>
+                    </dl>
+
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                      <div
+                        className={`rounded border p-4 ${
+                          isCorrect
+                            ? 'border-emerald-400/70 bg-emerald-950/40'
+                            : 'border-red-400/70 bg-red-950/40'
+                        }`}
+                      >
+                        <p className="text-sm text-[#d4ae6b]">選択した回答</p>
+                        <p className="mt-1 text-xl font-semibold">
+                          {selectedAnswer ?? '未回答'}
+                        </p>
+                      </div>
+                      <div className="rounded border border-emerald-400/70 bg-emerald-950/40 p-4">
+                        <p className="text-sm text-[#d4ae6b]">正解</p>
+                        <p className="mt-1 text-xl font-semibold">
+                          {question.correctAnswer}
+                        </p>
+                      </div>
+                    </div>
+
+                    <section
+                      aria-label={`問題${index + 1}の解説`}
+                      className="mt-6 rounded border border-[#c6a160] bg-[#031a14]/60 p-5"
+                    >
+                      <h3 className="font-semibold text-[#d4ae6b]">解説</h3>
+                      <p className="mt-2 leading-relaxed text-[#f5e7c8]">
+                        {question.explanation}
+                      </p>
+                    </section>
+                  </article>
+                </li>
+              )
+            },
+          )}
+        </ol>
+
+        <div className="mt-10 flex justify-center">
+          <BackButton onBack={onBack} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { render, screen } from '../../../test/test-utils'
 import type { QuizResult, RankCriterion } from '../../quiz'
@@ -11,6 +11,8 @@ const result: QuizResult = {
   totalScore: 1_500,
   totalQuestions: 10,
   elapsedTimeMs: 45_678,
+  questions: [],
+  answers: [],
 }
 
 const rankCriterion: RankCriterion = {
@@ -22,8 +24,15 @@ const rankCriterion: RankCriterion = {
 }
 
 describe('ResultPage', () => {
-  it('スコア・ランク・習熟度・正解数・回答時間を表示する', () => {
-    render(<ResultPage result={result} rankCriterion={rankCriterion} />)
+  it('スコア・ランク・習熟度・正解数・回答時間を表示する', async () => {
+    const onReview = vi.fn()
+    const { user } = render(
+      <ResultPage
+        result={result}
+        rankCriterion={rankCriterion}
+        onReview={onReview}
+      />,
+    )
 
     expect(screen.getByRole('heading', { name: '結果' })).toBeInTheDocument()
     expect(screen.getByLabelText('ランク')).toHaveTextContent('S')
@@ -31,5 +40,9 @@ describe('ResultPage', () => {
     expect(screen.getByText('1,500点')).toBeInTheDocument()
     expect(screen.getByText('8 / 10問')).toBeInTheDocument()
     expect(screen.getByText('45.678秒')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '10問の解説を見る' }))
+
+    expect(onReview).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -3,13 +3,18 @@ import type { QuizResult, RankCriterion } from '../../quiz'
 type ResultPageProps = {
   readonly result: QuizResult
   readonly rankCriterion: RankCriterion
+  readonly onReview: () => void
 }
 
 function formatElapsedTime(elapsedTimeMs: number): string {
   return `${(elapsedTimeMs / 1_000).toFixed(3)}秒`
 }
 
-export function ResultPage({ result, rankCriterion }: ResultPageProps) {
+export function ResultPage({
+  result,
+  rankCriterion,
+  onReview,
+}: ResultPageProps) {
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#031a14] px-4 py-8 text-[#f1d49e] sm:px-6">
       <div
@@ -56,6 +61,14 @@ export function ResultPage({ result, rankCriterion }: ResultPageProps) {
             </p>
           </div>
         </div>
+
+        <button
+          type="button"
+          className="mt-8 min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+          onClick={onReview}
+        >
+          10問の解説を見る
+        </button>
       </section>
     </main>
   )

--- a/frontend/src/features/result/containers/AnswerReviewPageContainer.test.tsx
+++ b/frontend/src/features/result/containers/AnswerReviewPageContainer.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '../../../test/test-utils'
+import { questions, type QuizResult } from '../../quiz'
+import { AnswerReviewPageContainer } from './AnswerReviewPageContainer'
+
+const result: QuizResult = {
+  correctCount: 1,
+  correctScore: 100,
+  timeBonus: 0,
+  totalScore: 100,
+  totalQuestions: 2,
+  elapsedTimeMs: 60_000,
+  questions: questions.slice(0, 2),
+  answers: [
+    {
+      questionId: questions[0].id,
+      selectedAnswer: questions[0].correctAnswer,
+    },
+    {
+      questionId: questions[1].id,
+      selectedAnswer: questions[1].choices.find(
+        (choice) => choice !== questions[1].correctAnswer,
+      )!,
+    },
+  ],
+}
+
+describe('AnswerReviewPageContainer', () => {
+  it('選択した回答と正解を比較して問題ごとの正誤を判定する', () => {
+    render(<AnswerReviewPageContainer result={result} onBack={vi.fn()} />)
+
+    expect(screen.getByLabelText('問題1の判定')).toHaveTextContent('正解')
+    expect(screen.getByLabelText('問題2の判定')).toHaveTextContent('不正解')
+  })
+})

--- a/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
+++ b/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
@@ -1,0 +1,30 @@
+import type { QuizResult } from '../../quiz'
+import { AnswerReviewPage } from '../components/AnswerReviewPage'
+
+type AnswerReviewPageContainerProps = {
+  readonly result: QuizResult
+  readonly onBack: () => void
+}
+
+export function AnswerReviewPageContainer({
+  result,
+  onBack,
+}: AnswerReviewPageContainerProps) {
+  const answerByQuestionId = new Map(
+    result.answers.map((answer) => [answer.questionId, answer]),
+  )
+  const reviewedQuestions = result.questions.map((question) => {
+    const answer = answerByQuestionId.get(question.id)
+    const selectedAnswer = answer?.selectedAnswer ?? null
+
+    return {
+      question,
+      selectedAnswer,
+      isCorrect: selectedAnswer === question.correctAnswer,
+    }
+  })
+
+  return (
+    <AnswerReviewPage reviewedQuestions={reviewedQuestions} onBack={onBack} />
+  )
+}

--- a/frontend/src/features/result/containers/ResultPageContainer.tsx
+++ b/frontend/src/features/result/containers/ResultPageContainer.tsx
@@ -3,10 +3,20 @@ import { ResultPage } from '../components/ResultPage'
 
 type ResultPageContainerProps = {
   readonly result: QuizResult
+  readonly onReview: () => void
 }
 
-export function ResultPageContainer({ result }: ResultPageContainerProps) {
+export function ResultPageContainer({
+  result,
+  onReview,
+}: ResultPageContainerProps) {
   const rankCriterion = determineRank(result.totalScore)
 
-  return <ResultPage result={result} rankCriterion={rankCriterion} />
+  return (
+    <ResultPage
+      result={result}
+      rankCriterion={rankCriterion}
+      onReview={onReview}
+    />
+  )
 }

--- a/frontend/src/features/result/index.ts
+++ b/frontend/src/features/result/index.ts
@@ -1,2 +1,5 @@
+export { AnswerReviewPage } from './components/AnswerReviewPage'
 export { ResultPage } from './components/ResultPage'
+export { AnswerReviewPageContainer } from './containers/AnswerReviewPageContainer'
 export { ResultPageContainer } from './containers/ResultPageContainer'
+export type { ReviewedQuestion } from './types/review'

--- a/frontend/src/features/result/types/review.ts
+++ b/frontend/src/features/result/types/review.ts
@@ -1,0 +1,7 @@
+import type { Question } from '../../quiz'
+
+export type ReviewedQuestion = {
+  readonly question: Question
+  readonly selectedAnswer: string | null
+  readonly isCorrect: boolean
+}


### PR DESCRIPTION
## 概要

10問分の正誤と解説を確認できる画面を実装しました。

## 対応内容

- 解説画面用のコンポーネントを作成
- 問題ごとの正誤を表示
- 選択した回答と正解を表示
- 役・翻・符・ドラを表示
- 問題ごとの解説文を表示
- 10問分をスクロールして確認できるように実装
- 結果画面から解説画面へ遷移できるように実装
- 問題データに役とドラの情報を追加
- 出題問題と回答履歴を結果データへ保持

## 動作確認

- [x] 10問分の解説が表示される
- [x] 各問題の正解・不正解が表示される
- [x] 選択した回答と正解が表示される
- [x] 役・翻・符・ドラが表示される
- [x] 解説文が表示される
- [x] 結果画面へ戻れる
- [x] `npm run format:check`が成功する
- [x] `npm run test:run`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #16