### PR TITLE
もう一度10問に挑戦できるようにする (#17)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -77,6 +77,35 @@ describe('App routing', () => {
     ).toBeInTheDocument()
   })
 
+  it('結果画面から状態を初期化して第1問へ再挑戦できる', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    for (let index = 0; index < 10; index += 1) {
+      await user.click(
+        screen
+          .getByRole('group', { name: '点数の選択肢' })
+          .querySelector('button')!,
+      )
+    }
+
+    expect(
+      await screen.findByRole('heading', { name: '結果' }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'もう一度挑戦' }))
+
+    expect(
+      await screen.findByRole('heading', { name: '1 / 10' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: '結果' }),
+    ).not.toBeInTheDocument()
+  })
+
   it.each(['/result', '/review'])(
     '結果データなしで%sを開くとトップ画面へ戻る',
     (path) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,20 +10,29 @@ import { TopPageContainer } from './features/top/containers/TopPageContainer'
 function App() {
   const navigate = useNavigate()
   const [quizResult, setQuizResult] = useState<QuizResult | null>(null)
+  const [isRetrying, setIsRetrying] = useState(false)
 
   const handleStart = useCallback(() => {
     setQuizResult(null)
+    setIsRetrying(false)
     navigate('/quiz')
   }, [navigate])
 
   const handleQuit = useCallback(() => {
     setQuizResult(null)
+    setIsRetrying(false)
     navigate('/')
   }, [navigate])
+
+  const handleRetry = useCallback(() => {
+    setQuizResult(null)
+    setIsRetrying(true)
+  }, [])
 
   const handleComplete = useCallback(
     (result: QuizResult) => {
       setQuizResult(result)
+      setIsRetrying(false)
       navigate('/result')
     },
     [navigate],
@@ -42,11 +51,12 @@ function App() {
         path="/result"
         element={
           quizResult === null ? (
-            <Navigate to="/" replace />
+            <Navigate to={isRetrying ? '/quiz' : '/'} replace />
           ) : (
             <ResultPageContainer
               result={quizResult}
               onReview={() => navigate('/review')}
+              onRetry={handleRetry}
             />
           )
         }
@@ -55,7 +65,7 @@ function App() {
         path="/review"
         element={
           quizResult === null ? (
-            <Navigate to="/" replace />
+            <Navigate to={isRetrying ? '/quiz' : '/'} replace />
           ) : (
             <AnswerReviewPageContainer
               result={quizResult}

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -26,11 +26,13 @@ const rankCriterion: RankCriterion = {
 describe('ResultPage', () => {
   it('スコア・ランク・習熟度・正解数・回答時間を表示する', async () => {
     const onReview = vi.fn()
+    const onRetry = vi.fn()
     const { user } = render(
       <ResultPage
         result={result}
         rankCriterion={rankCriterion}
         onReview={onReview}
+        onRetry={onRetry}
       />,
     )
 
@@ -44,5 +46,21 @@ describe('ResultPage', () => {
     await user.click(screen.getByRole('button', { name: '10問の解説を見る' }))
 
     expect(onReview).toHaveBeenCalledOnce()
+  })
+
+  it('もう一度挑戦ボタンから再挑戦を通知する', async () => {
+    const onRetry = vi.fn()
+    const { user } = render(
+      <ResultPage
+        result={result}
+        rankCriterion={rankCriterion}
+        onReview={vi.fn()}
+        onRetry={onRetry}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'もう一度挑戦' }))
+
+    expect(onRetry).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -4,6 +4,7 @@ type ResultPageProps = {
   readonly result: QuizResult
   readonly rankCriterion: RankCriterion
   readonly onReview: () => void
+  readonly onRetry: () => void
 }
 
 function formatElapsedTime(elapsedTimeMs: number): string {
@@ -14,6 +15,7 @@ export function ResultPage({
   result,
   rankCriterion,
   onReview,
+  onRetry,
 }: ResultPageProps) {
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#031a14] px-4 py-8 text-[#f1d49e] sm:px-6">
@@ -62,13 +64,22 @@ export function ResultPage({
           </div>
         </div>
 
-        <button
-          type="button"
-          className="mt-8 min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
-          onClick={onReview}
-        >
-          10問の解説を見る
-        </button>
+        <div className="mt-8 flex flex-wrap justify-center gap-4">
+          <button
+            type="button"
+            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            onClick={onRetry}
+          >
+            もう一度挑戦
+          </button>
+          <button
+            type="button"
+            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            onClick={onReview}
+          >
+            10問の解説を見る
+          </button>
+        </div>
       </section>
     </main>
   )

--- a/frontend/src/features/result/containers/ResultPageContainer.tsx
+++ b/frontend/src/features/result/containers/ResultPageContainer.tsx
@@ -4,11 +4,13 @@ import { ResultPage } from '../components/ResultPage'
 type ResultPageContainerProps = {
   readonly result: QuizResult
   readonly onReview: () => void
+  readonly onRetry: () => void
 }
 
 export function ResultPageContainer({
   result,
   onReview,
+  onRetry,
 }: ResultPageContainerProps) {
   const rankCriterion = determineRank({
     score: result.totalScore,
@@ -21,6 +23,7 @@ export function ResultPageContainer({
       result={result}
       rankCriterion={rankCriterion}
       onReview={onReview}
+      onRetry={onRetry}
     />
   )
 }


### PR DESCRIPTION
## 概要

結果画面から、状態を初期化してもう一度10問に挑戦できるようにしました。

## 対応内容

- 結果画面に「もう一度挑戦」ボタンを追加
- 前回の問題・回答・スコア・タイマーを初期化
- 問題選出処理を再実行
- `/quiz`へ遷移して第1問から再挑戦
- 再挑戦ボタンの単体テストを追加
- 再挑戦フローの画面遷移テストを追加

## 動作確認

- [x] 「もう一度挑戦」ボタンが表示される
- [x] ボタンから第1問へ移動できる
- [x] 前回の結果が初期化される
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run test:run`が成功する
- [x] `npm run build`が成功する
- [x] 18ファイル・85テストが成功する

Closes #17