### PR TITLE
結果・解説画面の導線と画面高さを調整する (#17)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -106,6 +106,32 @@ describe('App routing', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('結果画面からトップ画面へ戻れる', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    for (let index = 0; index < 10; index += 1) {
+      await user.click(
+        screen
+          .getByRole('group', { name: '点数の選択肢' })
+          .querySelector('button')!,
+      )
+    }
+
+    expect(
+      await screen.findByRole('heading', { name: '結果' }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'トップ画面' }))
+
+    expect(
+      await screen.findByRole('button', { name: 'スタート' }),
+    ).toBeInTheDocument()
+  })
+
   it.each(['/result', '/review'])(
     '結果データなしで%sを開くとトップ画面へ戻る',
     (path) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ function App() {
               result={quizResult}
               onReview={() => navigate('/review')}
               onRetry={handleRetry}
+              onTop={handleQuit}
             />
           )
         }
@@ -70,6 +71,8 @@ function App() {
             <AnswerReviewPageContainer
               result={quizResult}
               onBack={() => navigate('/result')}
+              onRetry={handleRetry}
+              onTop={handleQuit}
             />
           )
         }

--- a/frontend/src/features/quiz/components/AnswerChoices.tsx
+++ b/frontend/src/features/quiz/components/AnswerChoices.tsx
@@ -23,7 +23,7 @@ export function AnswerChoices({
             key={`${choice}-${index}`}
             type="button"
             aria-pressed={isSelected}
-            className={`min-h-16 cursor-pointer rounded border-2 px-4 py-3 text-lg font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] ${
+            className={`min-h-16 cursor-pointer rounded border-2 px-4 py-3 text-lg font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] [@media(max-height:900px)]:min-h-12 [@media(max-height:900px)]:py-2 ${
               isSelected
                 ? 'border-[#f1d49e] bg-[#1b4b36] text-[#f1d49e] ring-2 ring-[#d4ae6b]'
                 : 'border-[#c6a160] bg-[#f2e5c8] text-[#063b2b] hover:bg-[#f8efd9]'

--- a/frontend/src/features/quiz/components/DoraTiles.tsx
+++ b/frontend/src/features/quiz/components/DoraTiles.tsx
@@ -7,6 +7,8 @@ type DoraTilesProps = {
 }
 
 export function DoraTiles({ tiles, compact = false }: DoraTilesProps) {
+  const emptyStateSizeClass = compact ? 'w-10' : 'w-10 sm:w-12 md:w-14'
+
   return (
     <div
       role="group"
@@ -14,7 +16,11 @@ export function DoraTiles({ tiles, compact = false }: DoraTilesProps) {
       className="flex items-end justify-center gap-1"
     >
       {tiles.length === 0 ? (
-        <span className="text-sm text-[#f5e7c8]">なし</span>
+        <span
+          className={`flex aspect-[3/4] shrink-0 items-center justify-center text-sm text-[#f5e7c8] ${emptyStateSizeClass}`}
+        >
+          なし
+        </span>
       ) : (
         tiles.map((tile, index) => (
           <MahjongTile

--- a/frontend/src/features/quiz/components/QuizPage.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.tsx
@@ -22,13 +22,13 @@ export function QuizPage({
   const winTypeLabel = question.condition.winType === 'ron' ? 'ロン' : 'ツモ'
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-[#031a14] px-2 py-4 text-[#f1d49e] sm:px-4 sm:py-6">
+    <main className="relative min-h-svh overflow-x-hidden bg-[#031a14] px-2 py-4 text-[#f1d49e] sm:px-4 sm:py-6 [@media(max-height:900px)]:py-2">
       <div
         aria-hidden="true"
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.7),transparent_58%),linear-gradient(135deg,rgba(198,161,96,0.08),transparent_45%)]"
       />
-      <div className="relative mx-auto w-full max-w-none rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:p-8">
-        <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+      <div className="relative mx-auto w-full max-w-none rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:p-8 [@media(max-height:900px)]:p-4">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 [@media(max-height:900px)]:gap-4">
           <header className="relative text-center">
             <div className="mb-4 flex justify-end sm:absolute sm:top-0 sm:right-0 sm:mb-0">
               <button
@@ -40,28 +40,28 @@ export function QuizPage({
               </button>
             </div>
             <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">QUESTION</p>
-            <h1 className="mt-1 text-3xl font-semibold">
+            <h1 className="mt-1 text-3xl font-semibold [@media(max-height:900px)]:text-2xl">
               {currentQuestionNumber} / {totalQuestions}
             </h1>
             <progress
               aria-label="問題の進捗"
               value={currentQuestionNumber}
               max={totalQuestions}
-              className="progress mt-4 h-3 w-full bg-[#02140f] [&::-moz-progress-bar]:bg-[#d4ae6b] [&::-webkit-progress-value]:bg-[#d4ae6b]"
+              className="progress mt-4 h-3 w-full bg-[#02140f] [&::-moz-progress-bar]:bg-[#d4ae6b] [&::-webkit-progress-value]:bg-[#d4ae6b] [@media(max-height:900px)]:mt-2"
             />
           </header>
 
           <section
             aria-labelledby="question-condition-heading"
-            className="rounded border border-[#c6a160] bg-black/20 p-5"
+            className="rounded border border-[#c6a160] bg-black/20 p-5 [@media(max-height:900px)]:p-3"
           >
             <h2
               id="question-condition-heading"
-              className="text-center text-xl font-semibold"
+              className="text-center text-xl font-semibold [@media(max-height:900px)]:text-lg"
             >
               問題の条件
             </h2>
-            <dl className="mt-4 flex flex-wrap justify-center gap-x-8 gap-y-3 text-lg">
+            <dl className="mt-4 flex flex-wrap justify-center gap-x-8 gap-y-3 text-lg [@media(max-height:900px)]:mt-2 [@media(max-height:900px)]:gap-y-1 [@media(max-height:900px)]:text-base">
               <div className="flex gap-2">
                 <dt className="text-[#d4ae6b]">家</dt>
                 <dd>{playerLabel}</dd>
@@ -76,8 +76,8 @@ export function QuizPage({
               </div>
             </dl>
 
-            <div className="mt-5 border-t border-[#c6a160]/40 pt-4">
-              <p className="mb-3 text-center text-sm font-semibold text-[#d4ae6b]">
+            <div className="mt-5 border-t border-[#c6a160]/40 pt-4 [@media(max-height:900px)]:mt-2 [@media(max-height:900px)]:pt-2">
+              <p className="mb-3 text-center text-sm font-semibold text-[#d4ae6b] [@media(max-height:900px)]:mb-1">
                 ドラ牌
               </p>
               <DoraTiles tiles={question.doraTiles} />
@@ -86,11 +86,11 @@ export function QuizPage({
 
           <section
             aria-labelledby="winning-hand-heading"
-            className="rounded border border-[#c6a160] bg-black/20 p-5"
+            className="rounded border border-[#c6a160] bg-black/20 p-5 [@media(max-height:900px)]:p-3"
           >
             <h2
               id="winning-hand-heading"
-              className="mb-5 text-center text-xl font-semibold"
+              className="mb-5 text-center text-xl font-semibold [@media(max-height:900px)]:mb-2 [@media(max-height:900px)]:text-lg"
             >
               アガリ形
             </h2>
@@ -100,7 +100,7 @@ export function QuizPage({
           <section aria-labelledby="answer-heading">
             <h2
               id="answer-heading"
-              className="mb-4 text-center text-xl font-semibold"
+              className="mb-4 text-center text-xl font-semibold [@media(max-height:900px)]:mb-2 [@media(max-height:900px)]:text-lg"
             >
               点数を選択してください
             </h2>

--- a/frontend/src/features/result/components/AnswerReviewPage.test.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.test.tsx
@@ -21,6 +21,8 @@ describe('AnswerReviewPage', () => {
       <AnswerReviewPage
         reviewedQuestions={reviewedQuestions}
         onBack={vi.fn()}
+        onRetry={vi.fn()}
+        onTop={vi.fn()}
       />,
     )
 
@@ -69,11 +71,32 @@ describe('AnswerReviewPage', () => {
       <AnswerReviewPage
         reviewedQuestions={reviewedQuestions}
         onBack={onBack}
+        onRetry={vi.fn()}
+        onTop={vi.fn()}
       />,
     )
 
     await user.click(screen.getAllByRole('button', { name: '結果に戻る' })[0])
 
     expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('再挑戦とトップ画面への移動を通知する', async () => {
+    const onRetry = vi.fn()
+    const onTop = vi.fn()
+    const { user } = render(
+      <AnswerReviewPage
+        reviewedQuestions={reviewedQuestions}
+        onBack={vi.fn()}
+        onRetry={onRetry}
+        onTop={onTop}
+      />,
+    )
+
+    await user.click(screen.getAllByRole('button', { name: 'もう一度挑戦' })[0])
+    await user.click(screen.getAllByRole('button', { name: 'トップ画面' })[0])
+
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(onTop).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/result/components/AnswerReviewPage.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.tsx
@@ -4,23 +4,49 @@ import type { ReviewedQuestion } from '../types/review'
 type AnswerReviewPageProps = {
   readonly reviewedQuestions: readonly ReviewedQuestion[]
   readonly onBack: () => void
+  readonly onRetry: () => void
+  readonly onTop: () => void
 }
 
-function BackButton({ onBack }: { readonly onBack: () => void }) {
+type ReviewActionsProps = {
+  readonly onBack: () => void
+  readonly onRetry: () => void
+  readonly onTop: () => void
+}
+
+function ReviewActions({ onBack, onRetry, onTop }: ReviewActionsProps) {
   return (
-    <button
-      type="button"
-      className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-6 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
-      onClick={onBack}
-    >
-      結果に戻る
-    </button>
+    <div className="flex flex-wrap justify-center gap-3">
+      <button
+        type="button"
+        className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-6 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        onClick={onBack}
+      >
+        結果に戻る
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-6 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        onClick={onRetry}
+      >
+        もう一度挑戦
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-6 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        onClick={onTop}
+      >
+        トップ画面
+      </button>
+    </div>
   )
 }
 
 export function AnswerReviewPage({
   reviewedQuestions,
   onBack,
+  onRetry,
+  onTop,
 }: AnswerReviewPageProps) {
   return (
     <main className="relative min-h-screen bg-[#031a14] px-3 py-6 text-[#f1d49e] sm:px-6 sm:py-10">
@@ -37,7 +63,7 @@ export function AnswerReviewPage({
               10問の解説
             </h1>
           </div>
-          <BackButton onBack={onBack} />
+          <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
         </header>
 
         <ol className="mt-8 space-y-8">
@@ -140,8 +166,8 @@ export function AnswerReviewPage({
           )}
         </ol>
 
-        <div className="mt-10 flex justify-center">
-          <BackButton onBack={onBack} />
+        <div className="mt-10">
+          <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
         </div>
       </div>
     </main>

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -27,12 +27,14 @@ describe('ResultPage', () => {
   it('スコア・ランク・習熟度・正解数・回答時間を表示する', async () => {
     const onReview = vi.fn()
     const onRetry = vi.fn()
+    const onTop = vi.fn()
     const { user } = render(
       <ResultPage
         result={result}
         rankCriterion={rankCriterion}
         onReview={onReview}
         onRetry={onRetry}
+        onTop={onTop}
       />,
     )
 
@@ -56,11 +58,29 @@ describe('ResultPage', () => {
         rankCriterion={rankCriterion}
         onReview={vi.fn()}
         onRetry={onRetry}
+        onTop={vi.fn()}
       />,
     )
 
     await user.click(screen.getByRole('button', { name: 'もう一度挑戦' }))
 
     expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('トップ画面ボタンからトップ画面への遷移を通知する', async () => {
+    const onTop = vi.fn()
+    const { user } = render(
+      <ResultPage
+        result={result}
+        rankCriterion={rankCriterion}
+        onReview={vi.fn()}
+        onRetry={vi.fn()}
+        onTop={onTop}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'トップ画面' }))
+
+    expect(onTop).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -5,6 +5,7 @@ type ResultPageProps = {
   readonly rankCriterion: RankCriterion
   readonly onReview: () => void
   readonly onRetry: () => void
+  readonly onTop: () => void
 }
 
 function formatElapsedTime(elapsedTimeMs: number): string {
@@ -16,6 +17,7 @@ export function ResultPage({
   rankCriterion,
   onReview,
   onRetry,
+  onTop,
 }: ResultPageProps) {
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#031a14] px-4 py-8 text-[#f1d49e] sm:px-6">
@@ -78,6 +80,13 @@ export function ResultPage({
             onClick={onReview}
           >
             10問の解説を見る
+          </button>
+          <button
+            type="button"
+            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            onClick={onTop}
+          >
+            トップ画面
           </button>
         </div>
       </section>

--- a/frontend/src/features/result/containers/AnswerReviewPageContainer.test.tsx
+++ b/frontend/src/features/result/containers/AnswerReviewPageContainer.test.tsx
@@ -28,7 +28,14 @@ const result: QuizResult = {
 
 describe('AnswerReviewPageContainer', () => {
   it('選択した回答と正解を比較して問題ごとの正誤を判定する', () => {
-    render(<AnswerReviewPageContainer result={result} onBack={vi.fn()} />)
+    render(
+      <AnswerReviewPageContainer
+        result={result}
+        onBack={vi.fn()}
+        onRetry={vi.fn()}
+        onTop={vi.fn()}
+      />,
+    )
 
     expect(screen.getByLabelText('問題1の判定')).toHaveTextContent('正解')
     expect(screen.getByLabelText('問題2の判定')).toHaveTextContent('不正解')

--- a/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
+++ b/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
@@ -4,11 +4,15 @@ import { AnswerReviewPage } from '../components/AnswerReviewPage'
 type AnswerReviewPageContainerProps = {
   readonly result: QuizResult
   readonly onBack: () => void
+  readonly onRetry: () => void
+  readonly onTop: () => void
 }
 
 export function AnswerReviewPageContainer({
   result,
   onBack,
+  onRetry,
+  onTop,
 }: AnswerReviewPageContainerProps) {
   const answerByQuestionId = new Map(
     result.answers.map((answer) => [answer.questionId, answer]),
@@ -25,6 +29,11 @@ export function AnswerReviewPageContainer({
   })
 
   return (
-    <AnswerReviewPage reviewedQuestions={reviewedQuestions} onBack={onBack} />
+    <AnswerReviewPage
+      reviewedQuestions={reviewedQuestions}
+      onBack={onBack}
+      onRetry={onRetry}
+      onTop={onTop}
+    />
   )
 }

--- a/frontend/src/features/result/containers/ResultPageContainer.tsx
+++ b/frontend/src/features/result/containers/ResultPageContainer.tsx
@@ -5,12 +5,14 @@ type ResultPageContainerProps = {
   readonly result: QuizResult
   readonly onReview: () => void
   readonly onRetry: () => void
+  readonly onTop: () => void
 }
 
 export function ResultPageContainer({
   result,
   onReview,
   onRetry,
+  onTop,
 }: ResultPageContainerProps) {
   const rankCriterion = determineRank({
     score: result.totalScore,
@@ -24,6 +26,7 @@ export function ResultPageContainer({
       rankCriterion={rankCriterion}
       onReview={onReview}
       onRetry={onRetry}
+      onTop={onTop}
     />
   )
 }

--- a/frontend/src/features/top/components/TopActions.tsx
+++ b/frontend/src/features/top/components/TopActions.tsx
@@ -14,11 +14,11 @@ export function TopActions({
   return (
     <nav
       aria-label="トップ画面メニュー"
-      className="flex flex-col items-center gap-4 sm:gap-5"
+      className="flex flex-col items-center gap-4 sm:gap-5 [@media(max-height:850px)]:gap-2"
     >
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.primaryButton} min-h-32 w-full cursor-pointer px-8 py-4 text-5xl font-semibold tracking-[0.28em] text-[#f1d49e] sm:min-h-40 sm:text-6xl`}
+        className={`${styles.ornateButton} ${styles.primaryButton} min-h-32 w-full cursor-pointer px-8 py-4 text-5xl font-semibold tracking-[0.28em] text-[#f1d49e] sm:min-h-40 sm:text-6xl [@media(max-height:850px)]:min-h-24 [@media(max-height:850px)]:text-4xl`}
         onClick={onStart}
       >
         <span className={styles.label}>スタート</span>
@@ -26,7 +26,7 @@ export function TopActions({
 
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.22em] text-[#063b2b] sm:min-h-24 sm:text-5xl`}
+        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.22em] text-[#063b2b] sm:min-h-24 sm:text-5xl [@media(max-height:850px)]:min-h-16 [@media(max-height:850px)]:text-3xl`}
         onClick={onOpenHowTo}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>
@@ -35,7 +35,7 @@ export function TopActions({
       </button>
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.18em] text-[#063b2b] sm:min-h-24 sm:text-5xl`}
+        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.18em] text-[#063b2b] sm:min-h-24 sm:text-5xl [@media(max-height:850px)]:min-h-16 [@media(max-height:850px)]:text-3xl`}
         onClick={onOpenScoreRank}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>

--- a/frontend/src/features/top/components/TopFooter.tsx
+++ b/frontend/src/features/top/components/TopFooter.tsx
@@ -1,6 +1,6 @@
 export function TopFooter() {
   return (
-    <footer className="relative z-30 px-4 py-5 sm:py-6">
+    <footer className="relative z-30 px-4 py-5 sm:py-6 [@media(max-height:850px)]:py-2">
       <nav aria-label="フッターメニュー">
         <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-[#e7d3aa] sm:text-base">
           <li>

--- a/frontend/src/features/top/components/TopPage.tsx
+++ b/frontend/src/features/top/components/TopPage.tsx
@@ -30,19 +30,19 @@ export function TopPage({
     >
       <div aria-hidden="true" className="absolute inset-0 bg-black/20" />
       <div className="relative z-20 flex min-h-svh flex-col">
-        <main className="flex flex-1 items-center justify-center px-4 py-12 sm:px-6">
-          <section className="flex w-full max-w-4xl -translate-y-6 flex-col items-center text-center">
-            <h1 className="bg-gradient-to-b from-[#fff1c7] via-[#d8ad68] to-[#9a682e] bg-clip-text text-5xl leading-tight font-bold tracking-[0.08em] text-transparent drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-7xl md:text-8xl lg:text-9xl">
+        <main className="flex flex-1 items-center justify-center px-4 py-12 sm:px-6 [@media(max-height:850px)]:py-3">
+          <section className="flex w-full max-w-4xl -translate-y-6 flex-col items-center text-center [@media(max-height:850px)]:translate-y-0">
+            <h1 className="bg-gradient-to-b from-[#fff1c7] via-[#d8ad68] to-[#9a682e] bg-clip-text text-5xl leading-tight font-bold tracking-[0.08em] text-transparent drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-7xl md:text-8xl lg:text-9xl [@media(max-height:850px)]:text-6xl">
               麻雀レベル++
             </h1>
 
-            <p className="mt-4 text-base font-semibold tracking-[0.28em] text-[#e8c58d] drop-shadow-[0_2px_2px_rgba(0,0,0,0.9)] sm:text-xl md:text-2xl">
+            <p className="mt-4 text-base font-semibold tracking-[0.28em] text-[#e8c58d] drop-shadow-[0_2px_2px_rgba(0,0,0,0.9)] sm:text-xl md:text-2xl [@media(max-height:850px)]:mt-2 [@media(max-height:850px)]:text-lg">
               点数計算を、速く、正確に
             </p>
 
             <div
               aria-hidden="true"
-              className="my-6 flex w-full max-w-xl items-center gap-4 text-[#c99b55]"
+              className="my-6 flex w-full max-w-xl items-center gap-4 text-[#c99b55] [@media(max-height:850px)]:my-3"
             >
               <span className="h-px flex-1 bg-current/60" />
               <span className="size-3 rotate-45 border border-current" />


### PR DESCRIPTION
## 動作確認

- [x] 結果画面から再挑戦できる
- [x] 結果画面からトップ画面へ戻れる
- [x] 解説画面から再挑戦できる
- [x] 解説画面からトップ画面へ戻れる
- [x] ドラ牌の有無で表示領域が変わらない
- [x] 高さが低い画面でトップ画面のフッターが収まる
- [x] 高さが低い画面で問題画面の金枠が収まりやすい
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run test:run`が成功する
- [x] `npm run build`が成功する
- [x] 18ファイル・88テストが成功する

Closes #17