### PR TITLE
問題データ・出題・採点・ランク判定の単体テストを拡充する (#25)

### DIFF
--- a/frontend/src/features/quiz/data/question.test.ts
+++ b/frontend/src/features/quiz/data/question.test.ts
@@ -11,6 +11,48 @@ describe('questions', () => {
     expect(questions).toHaveLength(10)
   })
 
+  it('すべての問題に必須項目が正しく登録されている', () => {
+    const questionIds = questions.map((question) => question.id)
+
+    expect(new Set(questionIds).size).toBe(questions.length)
+
+    for (const question of questions) {
+      expect(question.id.trim()).not.toBe('')
+      expect(['A', 'B']).toContain(question.pattern)
+      expect(question.hand.concealedTiles.length).toBeGreaterThan(0)
+      expect(question.hand.winningTile).toBeTruthy()
+      expect(['dealer', 'nonDealer']).toContain(question.condition.player)
+      expect(['ron', 'tsumo']).toContain(question.condition.winType)
+      expect(question.choices).toHaveLength(3)
+      expect(new Set(question.choices).size).toBe(3)
+      expect(question.choices.every((choice) => choice.trim().length > 0)).toBe(
+        true,
+      )
+      expect(question.choices).toContain(question.correctAnswer)
+      expect(question.yaku.length).toBeGreaterThan(0)
+      expect(
+        question.yaku.every(
+          (yaku) =>
+            yaku.name.trim().length > 0 &&
+            Number.isInteger(yaku.han) &&
+            yaku.han > 0,
+        ),
+      ).toBe(true)
+      expect(Number.isInteger(question.han)).toBe(true)
+      expect(question.han).toBeGreaterThan(0)
+      expect(Number.isInteger(question.dora)).toBe(true)
+      expect(question.dora).toBeGreaterThanOrEqual(0)
+      expect(question.explanation.trim()).not.toBe('')
+
+      if (question.pattern === 'A') {
+        expect(question.fu).toBeNull()
+      } else {
+        expect(Number.isInteger(question.fu)).toBe(true)
+        expect(question.fu).toBeGreaterThan(0)
+      }
+    }
+  })
+
   it('パターンA・Bが5問ずつ登録されている', () => {
     expect(
       questions.filter((question) => question.pattern === 'A'),
@@ -88,16 +130,14 @@ describe('questions', () => {
     expect(questions.every((question) => question.dora <= 1)).toBe(true)
   })
 
-  it('パターンAとパターンBを識別できる', () => {
-    const patternAQuestion = questions.find(
-      (question) => question.pattern === 'A',
-    )
-    const patternBQuestion = questions.find(
-      (question) => question.pattern === 'B',
-    )
-
-    expect(patternAQuestion?.fu).toBeNull()
-    expect(patternBQuestion?.fu).toBeTypeOf('number')
+  it('パターンAとパターンBを符の有無で識別できる', () => {
+    for (const question of questions) {
+      if (question.pattern === 'A') {
+        expect(question.fu).toBeNull()
+      } else {
+        expect(question.fu).toBeTypeOf('number')
+      }
+    }
   })
 
   it('手牌・アガリ牌・副露を区別して管理できる', () => {

--- a/frontend/src/features/quiz/logic/calculateScore.test.ts
+++ b/frontend/src/features/quiz/logic/calculateScore.test.ts
@@ -26,15 +26,23 @@ describe('calculateScore', () => {
     expect(result.correctScore).toBe(5_000)
   })
 
-  it('正答率と回答時間からタイムボーナスを計算する', () => {
-    const result = calculateScore({
-      questions,
-      answers: createAnswers(10),
-      elapsedTimeMs: 120_000,
-    })
+  it.each([
+    { correctCount: 10, elapsedTimeMs: 60_000, expectedBonus: 500 },
+    { correctCount: 10, elapsedTimeMs: 120_000, expectedBonus: 250 },
+    { correctCount: 5, elapsedTimeMs: 60_000, expectedBonus: 250 },
+    { correctCount: 5, elapsedTimeMs: 120_000, expectedBonus: 125 },
+  ])(
+    '$correctCount問正解・$elapsedTimeMsミリ秒のタイムボーナスを計算する',
+    ({ correctCount, elapsedTimeMs, expectedBonus }) => {
+      const result = calculateScore({
+        questions,
+        answers: createAnswers(correctCount),
+        elapsedTimeMs,
+      })
 
-    expect(result.timeBonus).toBe(250)
-  })
+      expect(result.timeBonus).toBe(expectedBonus)
+    },
+  )
 
   it('正解点とタイムボーナスを合計する', () => {
     const result = calculateScore({
@@ -79,6 +87,20 @@ describe('calculateScore', () => {
     expect(zeroElapsedTime.timeBonus).toBe(0)
     expect(zeroElapsedTime.totalScore).toBe(10_000)
   })
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])(
+    '回答時間が不正な値（%s）の場合はタイムボーナスを0にする',
+    (elapsedTimeMs) => {
+      const result = calculateScore({
+        questions,
+        answers: createAnswers(10),
+        elapsedTimeMs,
+      })
+
+      expect(result.timeBonus).toBe(0)
+      expect(result.totalScore).toBe(10_000)
+    },
+  )
 
   it('同じ問題の回答が重複しても正解数を重複集計しない', () => {
     const duplicateAnswers = [

--- a/frontend/src/features/quiz/logic/selectQuestions.test.ts
+++ b/frontend/src/features/quiz/logic/selectQuestions.test.ts
@@ -97,6 +97,17 @@ describe('selectQuestions', () => {
     expect(selectedQuestionIds).not.toEqual(originalQuestionIds)
   })
 
+  it('選出しても元の問題データと順番を変更しない', () => {
+    const questions = createQuestions()
+    const originalQuestionIds = questions.map((question) => question.id)
+
+    selectQuestions(questions, () => 0)
+
+    expect(questions.map((question) => question.id)).toEqual(
+      originalQuestionIds,
+    )
+  })
+
   it('問題IDが重複している場合はエラーになる', () => {
     const questions = createQuestions(5, 5)
 


### PR DESCRIPTION
## 概要

問題データ・出題処理・スコア計算・タイムボーナス・ランク判定の単体テストを拡充しました。

## 対応内容

- 問題データの必須項目を検証
- 問題IDの一意性を検証
- 選択肢が3つあり、重複していないことを検証
- パターンA・Bの符の有無を検証
- パターンA・Bから5問ずつ選出されることを検証
- 出題処理が元データを変更しないことを検証
- 正解数と正解点の計算を検証
- 正答率と回答時間によるタイムボーナスを検証
- タイムボーナスの上限と異常値を検証
- G〜SSSのランク境界値を検証
- SSSは全問正解の場合のみ判定されることを検証

## 動作確認

- [x] Issue #25対象の4ファイル・52テストが成功する
- [x] 全18テストファイル・96テストが成功する
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #25