### PR TITLE
10問の回答フローのコンポーネントテストを拡充する (#26)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,6 +27,22 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
   })
 
+  it('選択肢から回答すると次の問題へ進む', async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={['/quiz']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    const answerChoices = screen.getByRole('group', {
+      name: '点数の選択肢',
+    })
+
+    await user.click(answerChoices.querySelector('button')!)
+
+    expect(screen.getByRole('heading', { name: '2 / 10' })).toBeInTheDocument()
+  })
+
   it('問題画面のやめるボタンから確認なしでトップ画面へ戻る', async () => {
     const { user } = render(
       <MemoryRouter initialEntries={['/quiz']}>
@@ -77,7 +93,7 @@ describe('App routing', () => {
     ).toBeInTheDocument()
   })
 
-  it('結果画面から状態を初期化して第1問へ再挑戦できる', async () => {
+  it('再挑戦と途中終了で状態を初期化して第1問から開始できる', async () => {
     const { user } = render(
       <MemoryRouter initialEntries={['/quiz']}>
         <App />
@@ -104,6 +120,22 @@ describe('App routing', () => {
     expect(
       screen.queryByRole('heading', { name: '結果' }),
     ).not.toBeInTheDocument()
+
+    await user.click(
+      screen
+        .getByRole('group', { name: '点数の選択肢' })
+        .querySelector('button')!,
+    )
+
+    expect(screen.getByRole('heading', { name: '2 / 10' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'やめる' }))
+
+    expect(screen.getByRole('button', { name: 'スタート' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'スタート' }))
+
+    expect(screen.getByRole('heading', { name: '1 / 10' })).toBeInTheDocument()
   })
 
   it('結果画面からトップ画面へ戻れる', async () => {


### PR DESCRIPTION
## 概要

スタートから10問回答、結果・解説表示、再挑戦・途中終了までのコンポーネントテストを拡充しました。

## 対応内容

- スタートボタンから第1問を表示できることを検証
- 選択肢を回答すると次の問題へ進むことを検証
- 10問回答後に結果画面が表示されることを検証
- 結果画面から解説画面を開けることを検証
- 結果画面から再挑戦できることを検証
- 再挑戦中に途中終了できることを検証
- 途中終了後に第1問から開始できることを検証

## 動作確認

- [x] Issue #26対象の3ファイル・15テストが成功する
- [x] 全18テストファイル・97テストが成功する
- [x] `npm run format:check`が成功する
- [x] `npm run lint`が成功する
- [x] `npm run build`が成功する

Closes #26