### PR TITLE
画面のレスポンシブ対応と表示を調整 (#23)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -121,7 +121,7 @@ describe('App routing', () => {
     expect(screen.getByText('正解数')).toBeInTheDocument()
     expect(screen.getByText('回答時間')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: '10問の解説を見る' }))
+    await user.click(screen.getByRole('button', { name: '解説を見る' }))
 
     expect(
       await screen.findByRole('heading', { name: '10問の解説' }),

--- a/frontend/src/features/privacy/components/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/privacy/components/PrivacyPolicyPage.tsx
@@ -6,31 +6,31 @@ const listClassName = 'list-disc space-y-2 pl-6'
 
 export function PrivacyPolicyPage() {
   return (
-    <main className="relative min-h-svh overflow-hidden bg-[#031a14] px-4 py-6 text-[#f5e7c8] sm:px-6 sm:py-10">
+    <main className="relative min-h-dvh overflow-x-hidden bg-[#031a14] px-3 py-4 text-[#f5e7c8] sm:px-6 sm:py-10">
       <div
         aria-hidden="true"
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.75),transparent_60%),linear-gradient(135deg,rgba(198,161,96,0.1),transparent_45%)]"
       />
 
       <div className="relative mx-auto w-full max-w-5xl">
-        <div className="mb-4 flex justify-end sm:mb-6">
+        <div className="mb-3 flex justify-end sm:mb-6">
           <Link
-            className="rounded border border-[#c6a160] bg-[#123727] px-5 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            className="w-full rounded border border-[#c6a160] bg-[#123727] px-4 py-3 text-center font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-5"
             to="/"
           >
             トップ画面へ戻る
           </Link>
         </div>
 
-        <article className="rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 px-5 py-8 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:px-10 sm:py-12">
-          <header className="border-b border-[#c6a160]/60 pb-6 text-center">
+        <article className="rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 px-4 py-6 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:rounded-xl sm:px-10 sm:py-12">
+          <header className="border-b border-[#c6a160]/60 pb-4 text-center sm:pb-6">
             <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">PRIVACY</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-[0.08em] text-[#f1d49e] sm:text-4xl">
+            <h1 className="mt-2 break-words text-2xl font-semibold tracking-[0.04em] text-[#f1d49e] sm:text-4xl sm:tracking-[0.08em]">
               プライバシーポリシー
             </h1>
           </header>
 
-          <div className="mt-8 space-y-10 leading-relaxed">
+          <div className="mt-6 space-y-8 text-sm leading-relaxed sm:mt-8 sm:space-y-10 sm:text-base">
             <p>
               「麻雀レベル++」（以下「本サービス」といいます。）は、利用者の情報を適切に取り扱うため、次のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。
             </p>

--- a/frontend/src/features/quiz/components/AnswerChoices.tsx
+++ b/frontend/src/features/quiz/components/AnswerChoices.tsx
@@ -13,7 +13,7 @@ export function AnswerChoices({
     <div
       role="group"
       aria-label="点数の選択肢"
-      className="grid w-full gap-3 sm:grid-cols-3"
+      className="grid w-full gap-2 sm:grid-cols-3 sm:gap-3 md:mx-auto md:w-2/3 xl:w-1/2"
     >
       {choices.map((choice, index) => {
         const isSelected = choice === selectedAnswer
@@ -23,7 +23,7 @@ export function AnswerChoices({
             key={`${choice}-${index}`}
             type="button"
             aria-pressed={isSelected}
-            className={`min-h-16 cursor-pointer rounded border-2 px-4 py-3 text-lg font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] [@media(max-height:900px)]:min-h-12 [@media(max-height:900px)]:py-2 ${
+            className={`min-h-12 cursor-pointer rounded border-2 px-3 py-2 text-base font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:min-h-16 sm:px-4 sm:py-3 sm:text-lg [@media(min-width:640px)_and_(max-height:900px)]:min-h-12 [@media(min-width:640px)_and_(max-height:900px)]:py-2 ${
               isSelected
                 ? 'border-[#f1d49e] bg-[#1b4b36] text-[#f1d49e] ring-2 ring-[#d4ae6b]'
                 : 'border-[#c6a160] bg-[#f2e5c8] text-[#063b2b] hover:bg-[#f8efd9]'

--- a/frontend/src/features/quiz/components/DoraTiles.tsx
+++ b/frontend/src/features/quiz/components/DoraTiles.tsx
@@ -7,7 +7,9 @@ type DoraTilesProps = {
 }
 
 export function DoraTiles({ tiles, compact = false }: DoraTilesProps) {
-  const emptyStateSizeClass = compact ? 'w-10' : 'w-10 sm:w-12 md:w-14'
+  const emptyStateSizeClass = compact
+    ? 'w-8 sm:w-10'
+    : 'w-8 sm:w-10 md:w-12 lg:w-14'
 
   return (
     <div

--- a/frontend/src/features/quiz/components/MahjongTile.tsx
+++ b/frontend/src/features/quiz/components/MahjongTile.tsx
@@ -11,7 +11,7 @@ export function MahjongTile({ tile, className = '' }: MahjongTileProps) {
     <img
       src={getMahjongTileImagePath(tile)}
       alt={`${tile}の麻雀牌`}
-      className={`block h-auto w-10 shrink-0 select-none rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] sm:w-12 md:w-14 ${className}`}
+      className={`block h-auto w-8 shrink-0 select-none rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] sm:w-10 md:w-12 lg:w-14 ${className}`}
       draggable="false"
     />
   )

--- a/frontend/src/features/quiz/components/QuizPage.test.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.test.tsx
@@ -5,7 +5,7 @@ import { questions } from '../data/question'
 import { QuizPage } from './QuizPage'
 
 describe('QuizPage', () => {
-  it('現在の問題番号・条件・ドラ牌・アガリ形・3つの選択肢を表示する', () => {
+  it('現在の問題番号・場風・自家・アガリ方・ドラ・アガリ役・3つの選択肢を表示する', () => {
     render(
       <QuizPage
         question={questions[0]}
@@ -20,9 +20,18 @@ describe('QuizPage', () => {
     expect(
       screen.getByRole('progressbar', { name: '問題の進捗' }),
     ).toHaveAttribute('value', '1')
-    expect(screen.getByText('子')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: '問題の条件' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('場風')).toBeInTheDocument()
+    expect(screen.getByText('東')).toBeInTheDocument()
+    expect(screen.getByText('自家')).toBeInTheDocument()
+    expect(screen.getByText('南家')).toBeInTheDocument()
     expect(screen.getByText('ロン')).toBeInTheDocument()
-    expect(screen.getByText('5翻')).toBeInTheDocument()
+    expect(screen.getByText('ドラ')).toBeInTheDocument()
+    expect(screen.queryByText('家')).not.toBeInTheDocument()
+    expect(screen.queryByText('翻数')).not.toBeInTheDocument()
+    expect(screen.queryByText('5翻')).not.toBeInTheDocument()
     expect(
       within(screen.getByRole('group', { name: 'ドラ牌' })).getAllByRole('img'),
     ).toHaveLength(1)
@@ -77,9 +86,7 @@ describe('QuizPage', () => {
       />,
     )
 
-    expect(
-      screen.getByRole('group', { name: '副露（ポン）' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'ポン' })).toBeInTheDocument()
   })
 
   it('やめるボタンからonQuitを通知する', async () => {

--- a/frontend/src/features/quiz/components/QuizPage.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.tsx
@@ -18,67 +18,74 @@ export function QuizPage({
   onAnswer,
   onQuit,
 }: QuizPageProps) {
-  const playerLabel = question.condition.player === 'dealer' ? '親' : '子'
+  const windLabels = {
+    east: '東',
+    south: '南',
+    west: '西',
+    north: '北',
+  } as const
   const winTypeLabel = question.condition.winType === 'ron' ? 'ロン' : 'ツモ'
+  const roundWindLabel = windLabels[question.condition.roundWind]
+  const seatWindLabel = `${windLabels[question.condition.seatWind]}家`
 
   return (
-    <main className="relative min-h-svh overflow-x-hidden bg-[#031a14] px-2 py-4 text-[#f1d49e] sm:px-4 sm:py-6 [@media(max-height:900px)]:py-2">
+    <main className="relative min-h-dvh overflow-x-hidden bg-[#031a14] px-2 py-2 text-[#f1d49e] sm:px-4 sm:py-4 lg:py-6 [@media(min-width:640px)_and_(max-height:900px)]:py-2">
       <div
         aria-hidden="true"
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.7),transparent_58%),linear-gradient(135deg,rgba(198,161,96,0.08),transparent_45%)]"
       />
-      <div className="relative mx-auto w-full max-w-none rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:p-8 [@media(max-height:900px)]:p-4">
-        <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 [@media(max-height:900px)]:gap-4">
+      <div className="relative mx-auto flex min-h-[calc(100dvh-1rem)] w-full max-w-none rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 p-3 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:min-h-[calc(100dvh-2rem)] sm:rounded-xl sm:p-6 lg:min-h-[calc(100dvh-3rem)] lg:p-8 [@media(min-width:640px)_and_(max-height:900px)]:min-h-[calc(100dvh-1rem)] [@media(min-width:640px)_and_(max-height:900px)]:p-4">
+        <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-5 sm:gap-6 lg:justify-between lg:gap-10 [@media(min-width:640px)_and_(max-height:900px)]:gap-4">
           <header className="relative text-center">
-            <div className="mb-4 flex justify-end sm:absolute sm:top-0 sm:right-0 sm:mb-0">
+            <div className="mb-2 flex justify-end sm:absolute sm:top-0 sm:right-0 sm:mb-0">
               <button
                 type="button"
-                className="cursor-pointer rounded border border-[#c6a160] bg-[#031a14]/70 px-4 py-2 text-sm font-semibold tracking-[0.12em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+                className="cursor-pointer rounded border border-[#c6a160] bg-[#031a14]/70 px-3 py-2 text-sm font-semibold tracking-[0.08em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:px-4 sm:tracking-[0.12em]"
                 onClick={onQuit}
               >
                 やめる
               </button>
             </div>
             <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">QUESTION</p>
-            <h1 className="mt-1 text-3xl font-semibold [@media(max-height:900px)]:text-2xl">
+            <h1 className="mt-1 text-2xl font-semibold sm:text-3xl [@media(min-width:640px)_and_(max-height:900px)]:text-2xl">
               {currentQuestionNumber} / {totalQuestions}
             </h1>
             <progress
               aria-label="問題の進捗"
               value={currentQuestionNumber}
               max={totalQuestions}
-              className="progress mt-4 h-3 w-full bg-[#02140f] [&::-moz-progress-bar]:bg-[#d4ae6b] [&::-webkit-progress-value]:bg-[#d4ae6b] [@media(max-height:900px)]:mt-2"
+              className="progress mt-3 h-3 w-full bg-[#02140f] [&::-moz-progress-bar]:bg-[#d4ae6b] [&::-webkit-progress-value]:bg-[#d4ae6b] sm:mt-4 [@media(min-width:640px)_and_(max-height:900px)]:mt-2"
             />
           </header>
 
           <section
-            aria-labelledby="question-condition-heading"
-            className="rounded border border-[#c6a160] bg-black/20 p-5 [@media(max-height:900px)]:p-3"
+            aria-label="問題の条件"
+            className="rounded border border-[#c6a160] bg-black/20 p-3 sm:p-5 [@media(min-width:640px)_and_(max-height:900px)]:p-3"
           >
-            <h2
-              id="question-condition-heading"
-              className="text-center text-xl font-semibold [@media(max-height:900px)]:text-lg"
-            >
-              問題の条件
-            </h2>
-            <dl className="mt-4 flex flex-wrap justify-center gap-x-8 gap-y-3 text-lg [@media(max-height:900px)]:mt-2 [@media(max-height:900px)]:gap-y-1 [@media(max-height:900px)]:text-base">
+            <dl className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm sm:gap-x-8 sm:gap-y-3 sm:text-lg [@media(min-width:640px)_and_(max-height:900px)]:gap-y-1 [@media(min-width:640px)_and_(max-height:900px)]:text-base">
               <div className="flex gap-2">
-                <dt className="text-[#d4ae6b]">家</dt>
-                <dd>{playerLabel}</dd>
+                <dt className="text-[#d4ae6b]">場風</dt>
+                <dd className="text-base font-semibold sm:text-xl">
+                  {roundWindLabel}
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="text-[#d4ae6b]">自家</dt>
+                <dd className="text-base font-semibold sm:text-xl">
+                  {seatWindLabel}
+                </dd>
               </div>
               <div className="flex gap-2">
                 <dt className="text-[#d4ae6b]">アガリ方</dt>
-                <dd>{winTypeLabel}</dd>
-              </div>
-              <div className="flex gap-2">
-                <dt className="text-[#d4ae6b]">翻数</dt>
-                <dd>{question.han}翻</dd>
+                <dd className="text-base font-semibold sm:text-xl">
+                  {winTypeLabel}
+                </dd>
               </div>
             </dl>
 
-            <div className="mt-5 border-t border-[#c6a160]/40 pt-4 [@media(max-height:900px)]:mt-2 [@media(max-height:900px)]:pt-2">
-              <p className="mb-3 text-center text-sm font-semibold text-[#d4ae6b] [@media(max-height:900px)]:mb-1">
-                ドラ牌
+            <div className="mt-3 border-t border-[#c6a160]/40 pt-3 sm:mt-5 sm:pt-4 [@media(min-width:640px)_and_(max-height:900px)]:mt-2 [@media(min-width:640px)_and_(max-height:900px)]:pt-2">
+              <p className="mb-2 text-center text-sm font-semibold text-[#d4ae6b] sm:mb-3 [@media(min-width:640px)_and_(max-height:900px)]:mb-1">
+                ドラ
               </p>
               <DoraTiles tiles={question.doraTiles} />
             </div>
@@ -86,13 +93,13 @@ export function QuizPage({
 
           <section
             aria-labelledby="winning-hand-heading"
-            className="rounded border border-[#c6a160] bg-black/20 p-5 [@media(max-height:900px)]:p-3"
+            className="rounded border border-[#c6a160] bg-black/20 p-3 sm:p-5 [@media(min-width:640px)_and_(max-height:900px)]:p-3"
           >
             <h2
               id="winning-hand-heading"
-              className="mb-5 text-center text-xl font-semibold [@media(max-height:900px)]:mb-2 [@media(max-height:900px)]:text-lg"
+              className="mb-3 text-center text-lg font-semibold sm:mb-5 sm:text-xl [@media(min-width:640px)_and_(max-height:900px)]:mb-2 [@media(min-width:640px)_and_(max-height:900px)]:text-lg"
             >
-              アガリ形
+              アガリ役
             </h2>
             <WinningHand hand={question.hand} />
           </section>
@@ -100,7 +107,7 @@ export function QuizPage({
           <section aria-labelledby="answer-heading">
             <h2
               id="answer-heading"
-              className="mb-4 text-center text-xl font-semibold [@media(max-height:900px)]:mb-2 [@media(max-height:900px)]:text-lg"
+              className="mb-3 text-center text-lg font-semibold sm:mb-4 sm:text-xl [@media(min-width:640px)_and_(max-height:900px)]:mb-2 [@media(min-width:640px)_and_(max-height:900px)]:text-lg"
             >
               点数を選択してください
             </h2>

--- a/frontend/src/features/quiz/components/WinningHand.test.tsx
+++ b/frontend/src/features/quiz/components/WinningHand.test.tsx
@@ -11,6 +11,7 @@ describe('WinningHand', () => {
     const concealedTiles = screen.getByRole('group', { name: '手牌' })
     const winningTile = screen.getByRole('group', { name: 'アガリ牌' })
 
+    expect(screen.queryByText('手牌')).not.toBeInTheDocument()
     expect(within(concealedTiles).getAllByRole('img')).toHaveLength(13)
     expect(within(winningTile).getAllByRole('img')).toHaveLength(1)
   })
@@ -18,9 +19,9 @@ describe('WinningHand', () => {
   it('副露の種類と牌を表示する', () => {
     render(<WinningHand hand={questions[7].hand} />)
 
-    const meld = screen.getByRole('group', { name: '副露（ポン）' })
+    const meld = screen.getByRole('group', { name: 'ポン' })
 
     expect(within(meld).getAllByRole('img')).toHaveLength(3)
-    expect(screen.getByText('副露（ポン）')).toBeInTheDocument()
+    expect(screen.getByText('ポン')).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/quiz/components/WinningHand.tsx
+++ b/frontend/src/features/quiz/components/WinningHand.tsx
@@ -13,10 +13,12 @@ type WinningHandProps = {
 
 export function WinningHand({ hand }: WinningHandProps) {
   return (
-    <section aria-label="アガリ形" className="overflow-x-auto pb-2">
-      <div className="flex min-w-max items-end gap-4">
+    <section
+      aria-label="アガリ役"
+      className="touch-pan-x overscroll-x-contain overflow-x-auto pb-2"
+    >
+      <div className="mx-auto flex w-max min-w-max items-end gap-2 sm:gap-4">
         <div>
-          <p className="mb-1 text-xs font-semibold text-[#f1d49e]">手牌</p>
           <div
             role="group"
             aria-label="手牌"
@@ -42,11 +44,11 @@ export function WinningHand({ hand }: WinningHandProps) {
         {hand.melds.map((meld, meldIndex) => (
           <div key={`${meld.type}-${meldIndex}`}>
             <p className="mb-1 text-xs font-semibold text-[#f1d49e]">
-              副露（{meldLabels[meld.type]}）
+              {meldLabels[meld.type]}
             </p>
             <div
               role="group"
-              aria-label={`副露（${meldLabels[meld.type]}）`}
+              aria-label={meldLabels[meld.type]}
               className="flex items-end gap-0.5 rounded bg-black/20 p-1"
             >
               {meld.tiles.map((tile, tileIndex) => (
@@ -60,6 +62,9 @@ export function WinningHand({ hand }: WinningHandProps) {
           </div>
         ))}
       </div>
+      <p className="mt-2 text-center text-xs text-[#d4ae6b] sm:hidden">
+        牌が見切れる場合は横にスクロールできます
+      </p>
     </section>
   )
 }

--- a/frontend/src/features/quiz/data/question.test.ts
+++ b/frontend/src/features/quiz/data/question.test.ts
@@ -23,6 +23,15 @@ describe('questions', () => {
       expect(question.hand.winningTile).toBeTruthy()
       expect(['dealer', 'nonDealer']).toContain(question.condition.player)
       expect(['ron', 'tsumo']).toContain(question.condition.winType)
+      expect(['east', 'south', 'west', 'north']).toContain(
+        question.condition.roundWind,
+      )
+      expect(['east', 'south', 'west', 'north']).toContain(
+        question.condition.seatWind,
+      )
+      expect(question.condition.player === 'dealer').toBe(
+        question.condition.seatWind === 'east',
+      )
       expect(question.choices).toHaveLength(3)
       expect(new Set(question.choices).size).toBe(3)
       expect(question.choices.every((choice) => choice.trim().length > 0)).toBe(

--- a/frontend/src/features/quiz/data/question.ts
+++ b/frontend/src/features/quiz/data/question.ts
@@ -26,6 +26,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'south',
     },
     choices: ['3,900点', '5,200点', '8,000点'],
     correctAnswer: '8,000点',
@@ -67,6 +69,8 @@ export const questions = [
     condition: {
       player: 'dealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'east',
     },
     choices: ['8,000点', '12,000点', '18,000点'],
     correctAnswer: '12,000点',
@@ -106,6 +110,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'south',
+      seatWind: 'west',
     },
     choices: ['8,000点', '12,000点', '16,000点'],
     correctAnswer: '12,000点',
@@ -114,7 +120,8 @@ export const questions = [
     fu: null,
     dora: 0,
     doraTiles: [],
-    explanation: '清一色6翻です。子のロン和了は跳満の12,000点になります。',
+    explanation:
+      '清一色（チンイツ）6翻です。子のロン和了は跳満の12,000点になります。',
   },
   {
     id: 'question-004',
@@ -141,6 +148,8 @@ export const questions = [
     condition: {
       player: 'dealer',
       winType: 'ron',
+      roundWind: 'south',
+      seatWind: 'east',
     },
     choices: ['12,000点', '18,000点', '24,000点'],
     correctAnswer: '18,000点',
@@ -149,7 +158,8 @@ export const questions = [
     fu: null,
     dora: 0,
     doraTiles: [],
-    explanation: '清一色6翻です。親のロン和了は跳満の18,000点になります。',
+    explanation:
+      '清一色（チンイツ）6翻です。親のロン和了は跳満の18,000点になります。',
   },
   {
     id: 'question-005',
@@ -176,6 +186,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'north',
     },
     choices: ['12,000点', '16,000点', '24,000点'],
     correctAnswer: '16,000点',
@@ -189,7 +201,7 @@ export const questions = [
     dora: 0,
     doraTiles: [],
     explanation:
-      '清一色6翻、一盃口1翻、リーチ1翻で計8翻です。子のロン和了は倍満の16,000点になります。',
+      '清一色（チンイツ）6翻、一盃口（イーペーコー）1翻、リーチ1翻で計8翻です。子のロン和了は倍満の16,000点になります。',
   },
   {
     id: 'question-006',
@@ -216,6 +228,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'tsumo',
+      roundWind: 'south',
+      seatWind: 'south',
     },
     choices: ['500点 / 1,000点', '700点 / 1,300点', '1,000点 / 2,000点'],
     correctAnswer: '700点 / 1,300点',
@@ -229,7 +243,7 @@ export const questions = [
     dora: 0,
     doraTiles: [],
     explanation:
-      '断么九（タンヤオ）1翻、平和（ピンフ）1翻、門前清自摸和（ツモ）1翻で計3翻です。子のツモ和了で20符3翻のため、親が1,300点、子が700点を支払います。',
+      '断么九（タンヤオ）1翻、平和（ピンフ）1翻、門前清自摸和（メンゼンツモ）1翻で計3翻です。子のツモ和了で20符3翻のため、親が1,300点、子が700点を支払います。',
   },
   {
     id: 'question-007',
@@ -256,6 +270,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'west',
     },
     choices: ['2,600点', '3,200点', '3,900点'],
     correctAnswer: '3,200点',
@@ -297,6 +313,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'south',
+      seatWind: 'north',
     },
     choices: ['3,900点', '5,200点', '7,700点'],
     correctAnswer: '5,200点',
@@ -309,7 +327,7 @@ export const questions = [
     dora: 0,
     doraTiles: [],
     explanation:
-      '対々和（トイトイ）2翻と役牌 中1翻で計3翻です。子のロン和了で40符3翻のため、5,200点になります。',
+      '対々和（トイトイ）2翻と役牌 中（ヤクハイ チュン）1翻で計3翻です。子のロン和了で40符3翻のため、5,200点になります。',
   },
   {
     id: 'question-009',
@@ -336,6 +354,8 @@ export const questions = [
     condition: {
       player: 'dealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'east',
     },
     choices: ['3,900点', '5,800点', '7,700点'],
     correctAnswer: '5,800点',
@@ -376,6 +396,8 @@ export const questions = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'west',
     },
     choices: ['2,600点', '3,200点', '3,900点'],
     correctAnswer: '3,200点',

--- a/frontend/src/features/quiz/index.ts
+++ b/frontend/src/features/quiz/index.ts
@@ -27,6 +27,7 @@ export type {
   QuestionHand,
   QuestionPattern,
   TileCode,
+  Wind,
   WinType,
   Yaku,
 } from './types/question'

--- a/frontend/src/features/quiz/logic/selectQuestions.test.ts
+++ b/frontend/src/features/quiz/logic/selectQuestions.test.ts
@@ -31,6 +31,8 @@ function createQuestion(
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'east',
+      seatWind: 'south',
     },
     choices: ['3,900点', '5,200点', '8,000点'],
     correctAnswer: '5,200点',

--- a/frontend/src/features/quiz/types/question.ts
+++ b/frontend/src/features/quiz/types/question.ts
@@ -33,10 +33,13 @@ export type QuestionPattern = 'A' | 'B'
 
 export type PlayerType = 'dealer' | 'nonDealer'
 export type WinType = 'ron' | 'tsumo'
+export type Wind = 'east' | 'south' | 'west' | 'north'
 
 export type QuestionCondition = {
   readonly player: PlayerType
   readonly winType: WinType
+  readonly roundWind: Wind
+  readonly seatWind: Wind
 }
 
 export type Yaku = {

--- a/frontend/src/features/result/components/AnswerReviewPage.test.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.test.tsx
@@ -39,7 +39,14 @@ describe('AnswerReviewPage', () => {
     expect(
       within(firstQuestion).getAllByText(questions[0].correctAnswer),
     ).toHaveLength(2)
-    expect(within(firstQuestion).getByText(/断么九（1翻）/)).toBeInTheDocument()
+    expect(
+      within(firstQuestion).getByText(
+        '断么九（タンヤオ）1翻、平和（ピンフ）1翻、一盃口（イーペーコー）1翻、リーチ1翻',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText(/門前清自摸和（メンゼンツモ）1翻/)).toHaveLength(
+      2,
+    )
     expect(within(firstQuestion).getByText('5翻')).toBeInTheDocument()
     expect(
       within(firstQuestion).getByText('計算不要（満貫以上）'),

--- a/frontend/src/features/result/components/AnswerReviewPage.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.tsx
@@ -14,26 +14,44 @@ type ReviewActionsProps = {
   readonly onTop: () => void
 }
 
+const yakuReadings: Readonly<Record<string, string>> = {
+  断么九: 'タンヤオ',
+  平和: 'ピンフ',
+  一盃口: 'イーペーコー',
+  混一色: 'ホンイツ',
+  七対子: 'チートイツ',
+  清一色: 'チンイツ',
+  門前清自摸和: 'メンゼンツモ',
+  対々和: 'トイトイ',
+  '役牌 中': 'ヤクハイ チュン',
+}
+
+function getYakuDisplayName(name: string): string {
+  const reading = yakuReadings[name]
+
+  return reading === undefined ? name : `${name}（${reading}）`
+}
+
 function ReviewActions({ onBack, onRetry, onTop }: ReviewActionsProps) {
   return (
-    <div className="flex flex-wrap justify-center gap-3">
+    <div className="flex w-full flex-col justify-center gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:gap-3">
       <button
         type="button"
-        className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-6 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-4 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
         onClick={onBack}
       >
         結果に戻る
       </button>
       <button
         type="button"
-        className="cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-6 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
         onClick={onRetry}
       >
         もう一度挑戦
       </button>
       <button
         type="button"
-        className="cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-6 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
         onClick={onTop}
       >
         トップ画面
@@ -49,67 +67,70 @@ export function AnswerReviewPage({
   onTop,
 }: AnswerReviewPageProps) {
   return (
-    <main className="relative min-h-screen bg-[#031a14] px-3 py-6 text-[#f1d49e] sm:px-6 sm:py-10">
+    <main className="relative min-h-dvh overflow-x-hidden bg-[#031a14] px-2 py-4 text-[#f1d49e] sm:px-6 sm:py-10">
       <div
         aria-hidden="true"
         className="fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.7),transparent_58%),linear-gradient(135deg,rgba(198,161,96,0.08),transparent_45%)]"
       />
 
       <div className="relative mx-auto w-full max-w-6xl">
-        <header className="flex flex-col items-center gap-5 text-center sm:flex-row sm:justify-between sm:text-left">
+        <header className="flex flex-col items-center gap-4 text-center sm:flex-row sm:justify-between sm:gap-5 sm:text-left">
           <div>
             <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">REVIEW</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-[0.12em] sm:text-4xl">
+            <h1 className="mt-2 text-2xl font-semibold tracking-[0.08em] sm:text-4xl sm:tracking-[0.12em]">
               10問の解説
             </h1>
           </div>
           <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
         </header>
 
-        <ol className="mt-8 space-y-8">
+        <ol className="mt-6 space-y-5 sm:mt-8 sm:space-y-8">
           {reviewedQuestions.map(
             ({ question, selectedAnswer, isCorrect }, index) => {
               const headingId = `review-question-${index + 1}`
               const yakuLabel = question.yaku
-                .map((yaku) => `${yaku.name}（${yaku.han}翻）`)
+                .map((yaku) => `${getYakuDisplayName(yaku.name)}${yaku.han}翻`)
                 .join('、')
 
               return (
                 <li key={question.id}>
                   <article
                     aria-labelledby={headingId}
-                    className="rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 p-5 shadow-[0_12px_30px_rgba(0,0,0,0.55)] sm:p-8"
+                    className="rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.55)] sm:rounded-xl sm:p-8"
                   >
                     <div className="flex flex-wrap items-center justify-between gap-3">
-                      <h2 id={headingId} className="text-2xl font-semibold">
+                      <h2
+                        id={headingId}
+                        className="text-xl font-semibold sm:text-2xl"
+                      >
                         問題 {index + 1}
                       </h2>
                       <span
                         aria-label={`問題${index + 1}の判定`}
-                        className={`rounded-full border px-4 py-1 text-sm font-semibold ${
+                        className={`rounded-full border-2 px-5 py-1.5 text-base font-bold sm:text-lg ${
                           isCorrect
-                            ? 'border-emerald-300 bg-emerald-950/70 text-emerald-200'
-                            : 'border-red-300 bg-red-950/70 text-red-200'
+                            ? 'border-emerald-200 bg-emerald-950/90 text-emerald-100'
+                            : 'border-red-200 bg-red-950/90 text-red-100'
                         }`}
                       >
                         {isCorrect ? '正解' : '不正解'}
                       </span>
                     </div>
 
-                    <div className="mt-6 rounded border border-[#c6a160]/70 bg-black/20 p-4 sm:p-5">
+                    <div className="mt-4 rounded border border-[#c6a160]/70 bg-black/20 p-3 sm:mt-6 sm:p-5">
                       <WinningHand hand={question.hand} />
                     </div>
 
-                    <dl className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                    <dl className="mt-4 grid gap-2 sm:mt-6 sm:grid-cols-2 sm:gap-3 lg:grid-cols-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:col-span-2 sm:p-4 lg:col-span-4">
                         <dt className="text-sm text-[#d4ae6b]">役</dt>
                         <dd className="mt-1">{yakuLabel}</dd>
                       </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
                         <dt className="text-sm text-[#d4ae6b]">翻</dt>
                         <dd className="mt-1">{question.han}翻</dd>
                       </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
                         <dt className="text-sm text-[#d4ae6b]">符</dt>
                         <dd className="mt-1">
                           {question.fu === null
@@ -117,34 +138,34 @@ export function AnswerReviewPage({
                             : `${question.fu}符`}
                         </dd>
                       </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
                         <dt className="text-sm text-[#d4ae6b]">ドラ牌</dt>
                         <dd className="mt-2">
                           <DoraTiles tiles={question.doraTiles} compact />
                         </dd>
                       </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-4">
+                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
                         <dt className="text-sm text-[#d4ae6b]">ドラ枚数</dt>
                         <dd className="mt-1">{question.dora}枚</dd>
                       </div>
                     </dl>
 
-                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                    <div className="mt-4 grid gap-3 sm:mt-6 sm:grid-cols-2 sm:gap-4">
                       <div
-                        className={`rounded border p-4 ${
+                        className={`rounded border-2 p-3 sm:p-4 ${
                           isCorrect
-                            ? 'border-emerald-400/70 bg-emerald-950/40'
-                            : 'border-red-400/70 bg-red-950/40'
+                            ? 'border-emerald-300 bg-emerald-950/85'
+                            : 'border-red-300 bg-red-950/85'
                         }`}
                       >
                         <p className="text-sm text-[#d4ae6b]">選択した回答</p>
-                        <p className="mt-1 text-xl font-semibold">
+                        <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
                           {selectedAnswer ?? '未回答'}
                         </p>
                       </div>
-                      <div className="rounded border border-emerald-400/70 bg-emerald-950/40 p-4">
+                      <div className="rounded border-2 border-emerald-300 bg-emerald-950/85 p-3 sm:p-4">
                         <p className="text-sm text-[#d4ae6b]">正解</p>
-                        <p className="mt-1 text-xl font-semibold">
+                        <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
                           {question.correctAnswer}
                         </p>
                       </div>
@@ -152,7 +173,7 @@ export function AnswerReviewPage({
 
                     <section
                       aria-label={`問題${index + 1}の解説`}
-                      className="mt-6 rounded border border-[#c6a160] bg-[#031a14]/60 p-5"
+                      className="mt-4 rounded border border-[#c6a160] bg-[#031a14]/60 p-3 sm:mt-6 sm:p-5"
                     >
                       <h3 className="font-semibold text-[#d4ae6b]">解説</h3>
                       <p className="mt-2 leading-relaxed text-[#f5e7c8]">
@@ -166,7 +187,7 @@ export function AnswerReviewPage({
           )}
         </ol>
 
-        <div className="mt-10">
+        <div className="mt-8 sm:mt-10">
           <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
         </div>
       </div>

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -10,7 +10,7 @@ const result: QuizResult = {
   timeBonus: 700,
   totalScore: 1_500,
   totalQuestions: 10,
-  elapsedTimeMs: 45_678,
+  elapsedTimeMs: 123_200,
   questions: [],
   answers: [],
 }
@@ -40,12 +40,13 @@ describe('ResultPage', () => {
 
     expect(screen.getByRole('heading', { name: '結果' })).toBeInTheDocument()
     expect(screen.getByLabelText('ランク')).toHaveTextContent('S')
+    expect(screen.getByLabelText('ランク')).toHaveClass('text-[#d946ef]')
     expect(screen.getByText('Sランクの習熟度説明です。')).toBeInTheDocument()
     expect(screen.getByText('1,500点')).toBeInTheDocument()
     expect(screen.getByText('8 / 10問')).toBeInTheDocument()
-    expect(screen.getByText('45.678秒')).toBeInTheDocument()
+    expect(screen.getByText('123秒200')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: '10問の解説を見る' }))
+    await user.click(screen.getByRole('button', { name: '解説を見る' }))
 
     expect(onReview).toHaveBeenCalledOnce()
   })

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -1,4 +1,4 @@
-import type { QuizResult, RankCriterion } from '../../quiz'
+import type { QuizResult, Rank, RankCriterion } from '../../quiz'
 
 type ResultPageProps = {
   readonly result: QuizResult
@@ -8,8 +8,24 @@ type ResultPageProps = {
   readonly onTop: () => void
 }
 
+const rankStyleClasses: Record<Rank, string> = {
+  G: 'text-[#94a3b8] [text-shadow:0_1px_0_#e2e8f0,0_3px_0_#475569,0_5px_0_#1e293b,0_9px_14px_rgba(0,0,0,0.75)]',
+  F: 'text-[#b7794b] [text-shadow:0_1px_0_#e7b98e,0_3px_0_#7c3f1d,0_5px_0_#4a2412,0_9px_14px_rgba(0,0,0,0.75)]',
+  E: 'text-[#22c55e] [text-shadow:0_1px_0_#86efac,0_3px_0_#15803d,0_5px_0_#14532d,0_9px_14px_rgba(0,0,0,0.75)]',
+  D: 'text-[#22d3ee] [text-shadow:0_1px_0_#a5f3fc,0_3px_0_#0891b2,0_5px_0_#164e63,0_9px_14px_rgba(0,0,0,0.75)]',
+  C: 'text-[#3b82f6] [text-shadow:0_1px_0_#93c5fd,0_3px_0_#1d4ed8,0_5px_0_#1e3a8a,0_9px_14px_rgba(0,0,0,0.75)]',
+  B: 'text-[#8b5cf6] [text-shadow:0_1px_0_#c4b5fd,0_3px_0_#6d28d9,0_5px_0_#4c1d95,0_9px_14px_rgba(0,0,0,0.75)]',
+  A: 'text-[#ef4444] [text-shadow:0_1px_0_#ff9a9a,0_3px_0_#a31313,0_5px_0_#6f0d0d,0_9px_14px_rgba(0,0,0,0.75)]',
+  S: 'text-[#d946ef] [text-shadow:0_1px_0_#f5d0fe,0_3px_0_#a21caf,0_5px_0_#701a75,0_9px_14px_rgba(0,0,0,0.75)]',
+  SS: 'text-[#e2e8f0] [text-shadow:0_1px_0_#ffffff,0_3px_0_#94a3b8,0_5px_0_#475569,0_9px_14px_rgba(0,0,0,0.8)]',
+  SSS: 'text-[#facc15] [text-shadow:0_1px_0_#fef3c7,0_3px_0_#d97706,0_5px_0_#92400e,0_9px_14px_rgba(0,0,0,0.8)]',
+}
+
 function formatElapsedTime(elapsedTimeMs: number): string {
-  return `${(elapsedTimeMs / 1_000).toFixed(3)}秒`
+  const seconds = Math.floor(elapsedTimeMs / 1_000)
+  const milliseconds = (elapsedTimeMs % 1_000).toString().padStart(3, '0')
+
+  return `${seconds}秒${milliseconds}`
 }
 
 export function ResultPage({
@@ -20,23 +36,22 @@ export function ResultPage({
   onTop,
 }: ResultPageProps) {
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#031a14] px-4 py-8 text-[#f1d49e] sm:px-6">
+    <main className="relative flex min-h-dvh items-center justify-center overflow-x-hidden bg-[#031a14] px-3 py-4 text-[#f1d49e] sm:px-6 sm:py-8">
       <div
         aria-hidden="true"
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.75),transparent_60%),linear-gradient(135deg,rgba(198,161,96,0.1),transparent_45%)]"
       />
 
-      <section className="relative w-full max-w-4xl rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 px-5 py-8 text-center shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:px-10 sm:py-12">
-        <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">RESULT</p>
-        <h1 className="mt-2 text-3xl font-semibold tracking-[0.15em] sm:text-4xl">
+      <section className="relative w-full max-w-4xl rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 px-4 py-6 text-center shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:px-10 sm:py-12">
+        <h1 className="text-3xl font-semibold tracking-[0.15em] sm:text-4xl">
           結果
         </h1>
 
-        <div className="mt-8">
+        <div className="mt-6 sm:mt-8">
           <p className="text-sm tracking-[0.2em] text-[#d4ae6b]">RANK</p>
           <p
             aria-label="ランク"
-            className="mt-2 text-7xl font-bold text-[#f1d49e] drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-8xl"
+            className={`mt-2 text-6xl font-black sm:text-8xl ${rankStyleClasses[rankCriterion.rank]}`}
           >
             {rankCriterion.rank}
           </p>
@@ -45,45 +60,45 @@ export function ResultPage({
           </p>
         </div>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-3">
-          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
-            <p className="text-sm text-[#d4ae6b]">スコア</p>
-            <p className="mt-2 text-3xl font-semibold">
+        <div className="mt-7 grid gap-3 sm:mt-10 sm:grid-cols-3 sm:gap-4">
+          <div className="rounded border-2 border-[#c6a160] bg-[#f2e5c8]/95 p-4 shadow-[inset_0_0_18px_rgba(198,161,96,0.22),0_6px_14px_rgba(0,0,0,0.35)] sm:p-5">
+            <p className="text-sm font-semibold text-[#7a571f]">スコア</p>
+            <p className="mt-1 text-2xl font-bold text-[#063b2b] sm:mt-2 sm:text-3xl">
               {result.totalScore.toLocaleString()}点
             </p>
           </div>
-          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
-            <p className="text-sm text-[#d4ae6b]">正解数</p>
-            <p className="mt-2 text-3xl font-semibold">
+          <div className="rounded border-2 border-[#c6a160] bg-[#f2e5c8]/95 p-4 shadow-[inset_0_0_18px_rgba(198,161,96,0.22),0_6px_14px_rgba(0,0,0,0.35)] sm:p-5">
+            <p className="text-sm font-semibold text-[#7a571f]">正解数</p>
+            <p className="mt-1 text-2xl font-bold text-[#063b2b] sm:mt-2 sm:text-3xl">
               {result.correctCount} / {result.totalQuestions}問
             </p>
           </div>
-          <div className="rounded border border-[#c6a160] bg-black/20 p-5">
-            <p className="text-sm text-[#d4ae6b]">回答時間</p>
-            <p className="mt-2 text-3xl font-semibold">
+          <div className="rounded border-2 border-[#c6a160] bg-[#f2e5c8]/95 p-4 shadow-[inset_0_0_18px_rgba(198,161,96,0.22),0_6px_14px_rgba(0,0,0,0.35)] sm:p-5">
+            <p className="text-sm font-semibold text-[#7a571f]">回答時間</p>
+            <p className="mt-1 text-2xl font-bold text-[#063b2b] sm:mt-2 sm:text-3xl">
               {formatElapsedTime(result.elapsedTimeMs)}
             </p>
           </div>
         </div>
 
-        <div className="mt-8 flex flex-wrap justify-center gap-4">
+        <div className="mt-6 flex flex-col justify-center gap-3 sm:mt-8 sm:flex-row sm:flex-wrap sm:gap-4">
           <button
             type="button"
-            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-3 py-2 text-sm font-semibold tracking-[0.04em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:min-w-44 sm:px-4 sm:py-2.5 sm:tracking-[0.08em]"
             onClick={onRetry}
           >
             もう一度挑戦
           </button>
           <button
             type="button"
-            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-3 py-2 text-sm font-semibold tracking-[0.04em] text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:min-w-44 sm:px-4 sm:py-2.5 sm:tracking-[0.08em]"
             onClick={onReview}
           >
-            10問の解説を見る
+            解説を見る
           </button>
           <button
             type="button"
-            className="min-w-64 cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-8 py-4 text-lg font-semibold tracking-[0.08em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-3 py-2 text-sm font-semibold tracking-[0.04em] text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:min-w-44 sm:px-4 sm:py-2.5 sm:tracking-[0.08em]"
             onClick={onTop}
           >
             トップ画面

--- a/frontend/src/features/terms/components/TermsPage.tsx
+++ b/frontend/src/features/terms/components/TermsPage.tsx
@@ -6,31 +6,31 @@ const listClassName = 'list-decimal space-y-2 pl-6'
 
 export function TermsPage() {
   return (
-    <main className="relative min-h-svh overflow-hidden bg-[#031a14] px-4 py-6 text-[#f5e7c8] sm:px-6 sm:py-10">
+    <main className="relative min-h-dvh overflow-x-hidden bg-[#031a14] px-3 py-4 text-[#f5e7c8] sm:px-6 sm:py-10">
       <div
         aria-hidden="true"
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(27,75,54,0.75),transparent_60%),linear-gradient(135deg,rgba(198,161,96,0.1),transparent_45%)]"
       />
 
       <div className="relative mx-auto w-full max-w-5xl">
-        <div className="mb-4 flex justify-end sm:mb-6">
+        <div className="mb-3 flex justify-end sm:mb-6">
           <Link
-            className="rounded border border-[#c6a160] bg-[#123727] px-5 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e]"
+            className="w-full rounded border border-[#c6a160] bg-[#123727] px-4 py-3 text-center font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-5"
             to="/"
           >
             トップ画面へ戻る
           </Link>
         </div>
 
-        <article className="rounded-xl border-2 border-[#c6a160] bg-[#082f25]/95 px-5 py-8 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:px-10 sm:py-12">
-          <header className="border-b border-[#c6a160]/60 pb-6 text-center">
+        <article className="rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 px-4 py-6 shadow-[0_16px_40px_rgba(0,0,0,0.7)] outline outline-1 -outline-offset-3 outline-[#d4ae6b]/40 sm:rounded-xl sm:px-10 sm:py-12">
+          <header className="border-b border-[#c6a160]/60 pb-4 text-center sm:pb-6">
             <p className="text-sm tracking-[0.3em] text-[#d4ae6b]">TERMS</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-[0.12em] text-[#f1d49e] sm:text-4xl">
+            <h1 className="mt-2 text-2xl font-semibold tracking-[0.08em] text-[#f1d49e] sm:text-4xl sm:tracking-[0.12em]">
               利用規約
             </h1>
           </header>
 
-          <div className="mt-8 space-y-10 leading-relaxed">
+          <div className="mt-6 space-y-8 text-sm leading-relaxed sm:mt-8 sm:space-y-10 sm:text-base">
             <p>
               この利用規約（以下「本規約」といいます。）は、「麻雀レベル++」（以下「本サービス」といいます。）の利用条件を定めるものです。本サービスを利用する方（以下「利用者」といいます。）は、本規約に同意したうえで本サービスをご利用ください。
             </p>

--- a/frontend/src/features/top/components/HowToDialog.tsx
+++ b/frontend/src/features/top/components/HowToDialog.tsx
@@ -32,15 +32,15 @@ export function HowToDialog({ isOpen, onClose }: HowToDialogProps) {
       onCancel={onClose}
       onClose={onClose}
     >
-      <section className="modal-box max-w-2xl border-2 border-[#c6a160] bg-[#0b3022] text-[#f1d49e] shadow-2xl">
+      <section className="modal-box max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-2xl overflow-y-auto border-2 border-[#c6a160] bg-[#0b3022] p-5 text-[#f1d49e] shadow-2xl sm:p-6">
         <h2
           id="how-to-dialog-title"
-          className="text-center text-3xl font-bold tracking-[0.2em]"
+          className="text-center text-2xl font-bold tracking-[0.14em] sm:text-3xl sm:tracking-[0.2em]"
         >
           遊び方
         </h2>
 
-        <ol className="mt-8 list-decimal space-y-4 pl-6 text-left text-base leading-relaxed text-[#f5e7c8] sm:text-lg">
+        <ol className="mt-5 list-decimal space-y-3 pl-5 text-left text-sm leading-relaxed text-[#f5e7c8] sm:mt-8 sm:space-y-4 sm:pl-6 sm:text-lg">
           <li>「スタート」ボタンを押して挑戦を開始します。</li>
           <li>表示された麻雀のアガリ形と条件を確認します。</li>
           <li>3つの選択肢から正しい点数を選びます。</li>
@@ -49,14 +49,14 @@ export function HowToDialog({ isOpen, onClose }: HowToDialogProps) {
           <li>10問終了後に、正解数・回答時間・ランクを確認します。</li>
         </ol>
 
-        <p className="mt-6 text-center text-sm text-[#d6bb88]">
+        <p className="mt-5 text-center text-xs text-[#d6bb88] sm:mt-6 sm:text-sm">
           正確さと回答の速さを意識して、高いスコアを目指しましょう。
         </p>
 
         <div className="modal-action justify-center">
           <button
             type="button"
-            className="min-w-40 cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-8 py-3 text-lg font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f]"
+            className="w-full cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-6 py-3 text-base font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f] sm:w-auto sm:min-w-40 sm:px-8 sm:text-lg"
             onClick={onClose}
           >
             閉じる

--- a/frontend/src/features/top/components/MahjongTileDecoration.tsx
+++ b/frontend/src/features/top/components/MahjongTileDecoration.tsx
@@ -12,12 +12,12 @@ export function MahjongTileDecoration() {
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute right-36 bottom-96 z-10 hidden origin-bottom-right -rotate-10 items-end opacity-80 md:flex"
+      className="pointer-events-none absolute -right-8 bottom-14 z-10 hidden origin-bottom-right -rotate-10 items-end opacity-75 xl:flex"
     >
       {tileNames.map((tileName, index) => (
         <div
           key={tileName}
-          className="relative -ml-3 aspect-[3/4] w-[clamp(6rem,7vw,9rem)] overflow-hidden rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] first:ml-0"
+          className="relative -ml-3 aspect-[3/4] w-[clamp(4.5rem,5vw,7rem)] overflow-hidden rounded-[10%] border border-[#b38a4f] bg-[#f2e5c8] p-0.5 shadow-[0_4px_8px_rgba(0,0,0,0.55)] first:ml-0"
           style={{ transform: `translateY(${index * -3}px)` }}
         >
           <img

--- a/frontend/src/features/top/components/ScoreRankDialog.test.tsx
+++ b/frontend/src/features/top/components/ScoreRankDialog.test.tsx
@@ -12,7 +12,7 @@ describe('ScoreRankDialog', () => {
         '正解1問につき1,000点、回答時間に応じて最大500点が加算されます。',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByText('10,000〜（10問全問正解）')).toBeInTheDocument()
+    expect(screen.getAllByText('10,000〜（10問全問正解）')).toHaveLength(2)
     expect(
       screen.getByText(/SSSランクは、10問全問正解かつ10,000点以上/),
     ).toBeInTheDocument()

--- a/frontend/src/features/top/components/ScoreRankDialog.tsx
+++ b/frontend/src/features/top/components/ScoreRankDialog.tsx
@@ -33,19 +33,38 @@ export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
       onCancel={onClose}
       onClose={onClose}
     >
-      <section className="modal-box max-h-[85svh] max-w-4xl overflow-y-auto border-2 border-[#c6a160] bg-[#0b3022] text-[#f1d49e] shadow-2xl">
+      <section className="modal-box max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-4xl overflow-y-auto border-2 border-[#c6a160] bg-[#0b3022] p-4 text-[#f1d49e] shadow-2xl sm:p-6">
         <h2
           id="score-rank-dialog-title"
-          className="text-center text-3xl font-bold tracking-[0.15em]"
+          className="text-center text-2xl font-bold tracking-[0.1em] sm:text-3xl sm:tracking-[0.15em]"
         >
           得点・ランク
         </h2>
 
-        <p className="mt-4 text-center text-[#f5e7c8]">
+        <p className="mt-3 text-center text-sm text-[#f5e7c8] sm:mt-4 sm:text-base">
           正解1問につき1,000点、回答時間に応じて最大500点が加算されます。
         </p>
 
-        <div className="mt-6 overflow-x-auto">
+        <ul className="mt-5 space-y-3 sm:hidden">
+          {rankCriteria.map(({ rank, scoreLabel, description }) => (
+            <li
+              key={rank}
+              className="rounded border border-[#c6a160]/50 bg-black/20 p-3"
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-2xl font-semibold text-[#f1d49e]">
+                  {rank}
+                </span>
+                <span className="text-sm text-[#e8c58d]">{scoreLabel}</span>
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-[#f5e7c8]">
+                {description}
+              </p>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-6 hidden overflow-x-auto sm:block">
           <table className="table">
             <thead>
               <tr className="border-[#c6a160] text-[#e8c58d]">
@@ -69,7 +88,7 @@ export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
           </table>
         </div>
 
-        <p className="mt-4 text-center text-sm text-[#d6bb88]">
+        <p className="mt-4 text-center text-xs leading-relaxed text-[#d6bb88] sm:text-sm">
           SSSランクは、10問全問正解かつ10,000点以上の場合に獲得できます。
           <br />
           ランクと説明は、本サービスのスコアをもとにした習熟度の目安です。
@@ -78,7 +97,7 @@ export function ScoreRankDialog({ isOpen, onClose }: ScoreRankDialogProps) {
         <div className="modal-action justify-center">
           <button
             type="button"
-            className="min-w-40 cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-8 py-3 text-lg font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f]"
+            className="w-full cursor-pointer border-2 border-[#a9854e] bg-[#efe4cb] px-6 py-3 text-base font-semibold tracking-[0.2em] text-[#063b2b] transition hover:bg-[#fff3d9] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#f2d18f] sm:w-auto sm:min-w-40 sm:px-8 sm:text-lg"
             onClick={onClose}
           >
             閉じる

--- a/frontend/src/features/top/components/TopActions.tsx
+++ b/frontend/src/features/top/components/TopActions.tsx
@@ -18,7 +18,7 @@ export function TopActions({
     >
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.primaryButton} min-h-32 w-full cursor-pointer px-8 py-4 text-5xl font-semibold tracking-[0.28em] text-[#f1d49e] sm:min-h-40 sm:text-6xl [@media(max-height:850px)]:min-h-24 [@media(max-height:850px)]:text-4xl`}
+        className={`${styles.ornateButton} ${styles.primaryButton} min-h-20 w-full cursor-pointer px-4 py-3 text-3xl font-semibold tracking-[0.18em] text-[#f1d49e] sm:min-h-32 sm:px-8 sm:py-4 sm:text-5xl sm:tracking-[0.28em] lg:min-h-40 lg:text-6xl [@media(min-width:640px)_and_(max-height:850px)]:min-h-24 [@media(min-width:640px)_and_(max-height:850px)]:text-4xl`}
         onClick={onStart}
       >
         <span className={styles.label}>スタート</span>
@@ -26,7 +26,7 @@ export function TopActions({
 
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.22em] text-[#063b2b] sm:min-h-24 sm:text-5xl [@media(max-height:850px)]:min-h-16 [@media(max-height:850px)]:text-3xl`}
+        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-14 w-full cursor-pointer px-4 py-2 text-2xl font-semibold tracking-[0.14em] text-[#063b2b] sm:min-h-20 sm:w-5/6 sm:px-6 sm:py-3 sm:text-4xl sm:tracking-[0.22em] lg:min-h-24 lg:text-5xl [@media(min-width:640px)_and_(max-height:850px)]:min-h-16 [@media(min-width:640px)_and_(max-height:850px)]:text-3xl`}
         onClick={onOpenHowTo}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>
@@ -35,7 +35,7 @@ export function TopActions({
       </button>
       <button
         type="button"
-        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-20 w-5/6 cursor-pointer px-6 py-3 text-4xl font-semibold tracking-[0.18em] text-[#063b2b] sm:min-h-24 sm:text-5xl [@media(max-height:850px)]:min-h-16 [@media(max-height:850px)]:text-3xl`}
+        className={`${styles.ornateButton} ${styles.secondaryButton} min-h-14 w-full cursor-pointer px-4 py-2 text-2xl font-semibold tracking-[0.12em] text-[#063b2b] sm:min-h-20 sm:w-5/6 sm:px-6 sm:py-3 sm:text-4xl sm:tracking-[0.18em] lg:min-h-24 lg:text-5xl [@media(min-width:640px)_and_(max-height:850px)]:min-h-16 [@media(min-width:640px)_and_(max-height:850px)]:text-3xl`}
         onClick={onOpenScoreRank}
       >
         <span className={`${styles.label} ${styles.secondaryLabel}`}>

--- a/frontend/src/features/top/components/TopFooter.tsx
+++ b/frontend/src/features/top/components/TopFooter.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export function TopFooter() {
   return (
-    <footer className="relative z-30 px-4 py-5 sm:py-6 [@media(max-height:850px)]:py-2">
+    <footer className="relative z-30 px-3 py-3 sm:px-4 sm:py-5 lg:py-6 [@media(min-width:640px)_and_(max-height:850px)]:py-2">
       <nav aria-label="フッターメニュー">
         <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-[#e7d3aa] sm:text-base">
           <li>

--- a/frontend/src/features/top/components/TopPage.tsx
+++ b/frontend/src/features/top/components/TopPage.tsx
@@ -25,24 +25,24 @@ export function TopPage({
 }: TopPageProps) {
   return (
     <div
-      className="relative min-h-svh overflow-hidden bg-cover bg-center font-['Yu_Mincho','Hiragino_Mincho_ProN',serif]"
+      className="relative min-h-dvh overflow-x-hidden bg-cover bg-center font-['Yu_Mincho','Hiragino_Mincho_ProN',serif]"
       style={{ backgroundImage: `url(${topBackground})` }}
     >
       <div aria-hidden="true" className="absolute inset-0 bg-black/20" />
-      <div className="relative z-20 flex min-h-svh flex-col">
-        <main className="flex flex-1 items-center justify-center px-4 py-12 sm:px-6 [@media(max-height:850px)]:py-3">
-          <section className="flex w-full max-w-4xl -translate-y-6 flex-col items-center text-center [@media(max-height:850px)]:translate-y-0">
-            <h1 className="bg-gradient-to-b from-[#fff1c7] via-[#d8ad68] to-[#9a682e] bg-clip-text text-5xl leading-tight font-bold tracking-[0.08em] text-transparent drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-7xl md:text-8xl lg:text-9xl [@media(max-height:850px)]:text-6xl">
+      <div className="relative z-20 flex min-h-dvh flex-col">
+        <main className="flex flex-1 items-center justify-center px-3 py-6 sm:px-6 sm:py-10 lg:py-12 [@media(min-width:640px)_and_(max-height:850px)]:py-3">
+          <section className="flex w-full max-w-4xl flex-col items-center text-center sm:-translate-y-4 lg:-translate-y-6 [@media(min-width:640px)_and_(max-height:850px)]:translate-y-0">
+            <h1 className="bg-gradient-to-b from-[#fff1c7] via-[#d8ad68] to-[#9a682e] bg-clip-text text-[clamp(2rem,10.5vw,4.5rem)] leading-tight font-bold tracking-[0.04em] text-transparent drop-shadow-[0_4px_3px_rgba(0,0,0,0.8)] sm:text-7xl sm:tracking-[0.08em] md:text-8xl lg:text-9xl [@media(min-width:640px)_and_(max-height:850px)]:text-6xl">
               麻雀レベル++
             </h1>
 
-            <p className="mt-4 text-base font-semibold tracking-[0.28em] text-[#e8c58d] drop-shadow-[0_2px_2px_rgba(0,0,0,0.9)] sm:text-xl md:text-2xl [@media(max-height:850px)]:mt-2 [@media(max-height:850px)]:text-lg">
+            <p className="mt-3 text-sm font-semibold tracking-[0.12em] text-[#e8c58d] drop-shadow-[0_2px_2px_rgba(0,0,0,0.9)] sm:mt-4 sm:text-xl sm:tracking-[0.28em] md:text-2xl [@media(min-width:640px)_and_(max-height:850px)]:mt-2 [@media(min-width:640px)_and_(max-height:850px)]:text-lg">
               点数計算を、速く、正確に
             </p>
 
             <div
               aria-hidden="true"
-              className="my-6 flex w-full max-w-xl items-center gap-4 text-[#c99b55] [@media(max-height:850px)]:my-3"
+              className="my-4 flex w-full max-w-xl items-center gap-3 text-[#c99b55] sm:my-6 sm:gap-4 [@media(min-width:640px)_and_(max-height:850px)]:my-3"
             >
               <span className="h-px flex-1 bg-current/60" />
               <span className="size-3 rotate-45 border border-current" />

--- a/frontend/src/test/fixtures/questions.ts
+++ b/frontend/src/test/fixtures/questions.ts
@@ -4,6 +4,8 @@ export type TestQuestion = {
   condition: {
     player: 'dealer' | 'nonDealer'
     winType: 'ron' | 'tsumo'
+    roundWind: 'east' | 'south' | 'west' | 'north'
+    seatWind: 'east' | 'south' | 'west' | 'north'
   }
   choices: readonly string[]
   correctAnswer: string
@@ -38,6 +40,8 @@ const baseTestQuestion: TestQuestion = {
   condition: {
     player: 'nonDealer',
     winType: 'ron',
+    roundWind: 'east',
+    seatWind: 'south',
   },
   choices: ['3,900点', '5,200点', '8,000点'],
   correctAnswer: '8,000点',
@@ -69,6 +73,8 @@ export const testQuestions: readonly TestQuestion[] = [
     condition: {
       player: 'nonDealer',
       winType: 'ron',
+      roundWind: 'south',
+      seatWind: 'west',
     },
     choices: ['3,900点', '5,200点', '7,700点'],
     correctAnswer: '5,200点',


### PR DESCRIPTION
## 概要

各画面のレスポンシブ対応と表示調整を実施しました。

## 対応内容

- PC・スマートフォンの画面幅に応じてレイアウトを調整
- ボタンや文字の画面外へのはみ出しを防止
- ダイアログを狭い画面でも確認できるように調整
- 問題画面の条件・アガリ役・点数ボタンを調整
- 場風と自家の問題データを追加
- 結果画面のランク・スコア・回答時間表示を調整
- 解説画面の正誤・役・回答欄の表示を調整
- 利用規約・プライバシーポリシーページをレスポンシブ対応

## 動作確認

- [x] PC相当の画面幅で表示できる
- [x] スマートフォン相当の画面幅で表示できる
- [x] Prettierが成功する
- [x] ESLintが成功する
- [x] 全99テストが成功する
- [x] 本番用ビルドが成功する

Closes #23