### PR TITLE
Fat Component・Fat Hookを責務ごとに分割 (#29)

### DIFF
--- a/frontend/src/features/quiz/containers/QuizPageContainer.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.tsx
@@ -3,7 +3,7 @@ import type { QuizResult } from '../types/score'
 import { QuizPage } from '../components/QuizPage'
 import { questions } from '../data/question'
 import { useQuizProgress } from '../hooks/useQuizProgress'
-import { calculateScore } from '../logic/calculateScore'
+import { createQuizResult } from '../logic/createQuizResult'
 import { selectQuestions } from '../logic/selectQuestions'
 
 type QuizPageContainerProps = {
@@ -26,17 +26,12 @@ export function QuizPageContainer({
     resetQuiz,
   } = useQuizProgress(quizQuestions)
   const result = useMemo<QuizResult>(
-    () => ({
-      ...calculateScore({
+    () =>
+      createQuizResult({
         questions: quizQuestions,
         answers,
         elapsedTimeMs,
       }),
-      totalQuestions: quizQuestions.length,
-      elapsedTimeMs,
-      questions: quizQuestions,
-      answers,
-    }),
     [answers, elapsedTimeMs, quizQuestions],
   )
 

--- a/frontend/src/features/quiz/hooks/useQuizProgress.ts
+++ b/frontend/src/features/quiz/hooks/useQuizProgress.ts
@@ -1,100 +1,30 @@
 import { useCallback, useReducer } from 'react'
 
-import type { QuizProgressState } from '../types/answer'
+import {
+  createQuizProgressState,
+  quizProgressReducer,
+} from '../logic/quizProgressReducer'
 import type { Question } from '../types/question'
 
-type ConfirmAnswerAction = {
-  readonly type: 'confirmAnswer'
-  readonly question: Question
-  readonly selectedAnswer: string
-  readonly totalQuestions: number
-  readonly confirmedAtMs: number
+type UseQuizProgressOptions = {
+  readonly now?: () => number
 }
-
-type ResetQuizAction = {
-  readonly type: 'resetQuiz'
-  readonly totalQuestions: number
-  readonly startedAtMs: number
-}
-
-type QuizProgressAction = ConfirmAnswerAction | ResetQuizAction
 
 type InitialStateArguments = {
   readonly totalQuestions: number
   readonly now: () => number
 }
 
-type UseQuizProgressOptions = {
-  readonly now?: () => number
-}
-
 const getCurrentTimeMs = () => performance.now()
 
-function createInitialState({
+function initializeQuizProgress({
   totalQuestions,
   now,
-}: InitialStateArguments): QuizProgressState {
-  const hasQuestions = totalQuestions > 0
-
-  return {
-    currentQuestionIndex: 0,
-    answers: [],
-    status: hasQuestions ? 'answering' : 'completed',
-    startedAtMs: hasQuestions ? now() : null,
-    elapsedTimeMs: 0,
-  }
-}
-
-function quizProgressReducer(
-  state: QuizProgressState,
-  action: QuizProgressAction,
-): QuizProgressState {
-  if (action.type === 'resetQuiz') {
-    const hasQuestions = action.totalQuestions > 0
-
-    return {
-      currentQuestionIndex: 0,
-      answers: [],
-      status: hasQuestions ? 'answering' : 'completed',
-      startedAtMs: hasQuestions ? action.startedAtMs : null,
-      elapsedTimeMs: 0,
-    }
-  }
-
-  if (state.status === 'completed') {
-    return state
-  }
-
-  const isAlreadyAnswered = state.answers.some(
-    (answer) => answer.questionId === action.question.id,
-  )
-
-  if (isAlreadyAnswered) {
-    return state
-  }
-
-  const answers = [
-    ...state.answers,
-    {
-      questionId: action.question.id,
-      selectedAnswer: action.selectedAnswer,
-    },
-  ]
-  const isLastQuestion = state.currentQuestionIndex >= action.totalQuestions - 1
-  const elapsedTimeMs =
-    state.startedAtMs === null
-      ? 0
-      : Math.max(0, Math.round(action.confirmedAtMs - state.startedAtMs))
-
-  return {
-    currentQuestionIndex: isLastQuestion
-      ? state.currentQuestionIndex
-      : state.currentQuestionIndex + 1,
-    answers,
-    status: isLastQuestion ? 'completed' : 'answering',
-    startedAtMs: state.startedAtMs,
-    elapsedTimeMs,
-  }
+}: InitialStateArguments) {
+  return createQuizProgressState({
+    totalQuestions,
+    startedAtMs: totalQuestions > 0 ? now() : null,
+  })
 }
 
 export function useQuizProgress(
@@ -108,7 +38,7 @@ export function useQuizProgress(
       totalQuestions: questions.length,
       now,
     },
-    createInitialState,
+    initializeQuizProgress,
   )
 
   const currentQuestion =
@@ -124,7 +54,7 @@ export function useQuizProgress(
 
       dispatch({
         type: 'confirmAnswer',
-        question: currentQuestion,
+        questionId: currentQuestion.id,
         selectedAnswer,
         totalQuestions: questions.length,
         confirmedAtMs: now(),

--- a/frontend/src/features/quiz/logic/createQuizResult.test.ts
+++ b/frontend/src/features/quiz/logic/createQuizResult.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { questions } from '../data/question'
+import { createQuizResult } from './createQuizResult'
+
+describe('createQuizResult', () => {
+  it('採点結果と問題・回答・経過時間を1つの結果にまとめる', () => {
+    const selectedQuestions = questions.slice(0, 2)
+    const answers = selectedQuestions.map((question) => ({
+      questionId: question.id,
+      selectedAnswer: question.correctAnswer,
+    }))
+
+    const result = createQuizResult({
+      questions: selectedQuestions,
+      answers,
+      elapsedTimeMs: 60_000,
+    })
+
+    expect(result.correctCount).toBe(2)
+    expect(result.totalQuestions).toBe(2)
+    expect(result.elapsedTimeMs).toBe(60_000)
+    expect(result.questions).toBe(selectedQuestions)
+    expect(result.answers).toBe(answers)
+  })
+})

--- a/frontend/src/features/quiz/logic/createQuizResult.ts
+++ b/frontend/src/features/quiz/logic/createQuizResult.ts
@@ -1,0 +1,24 @@
+import type { AnswerRecord } from '../types/answer'
+import type { Question } from '../types/question'
+import type { QuizResult } from '../types/score'
+import { calculateScore } from './calculateScore'
+
+type CreateQuizResultArguments = {
+  readonly questions: readonly Question[]
+  readonly answers: readonly AnswerRecord[]
+  readonly elapsedTimeMs: number
+}
+
+export function createQuizResult({
+  questions,
+  answers,
+  elapsedTimeMs,
+}: CreateQuizResultArguments): QuizResult {
+  return {
+    ...calculateScore({ questions, answers, elapsedTimeMs }),
+    totalQuestions: questions.length,
+    elapsedTimeMs,
+    questions,
+    answers,
+  }
+}

--- a/frontend/src/features/quiz/logic/quizProgressReducer.test.ts
+++ b/frontend/src/features/quiz/logic/quizProgressReducer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createQuizProgressState,
+  quizProgressReducer,
+} from './quizProgressReducer'
+
+describe('quizProgressReducer', () => {
+  it('回答を保存して次の問題へ進み、経過時間を更新する', () => {
+    const initialState = createQuizProgressState({
+      totalQuestions: 2,
+      startedAtMs: 100,
+    })
+
+    const state = quizProgressReducer(initialState, {
+      type: 'confirmAnswer',
+      questionId: 'question-1',
+      selectedAnswer: '8,000点',
+      totalQuestions: 2,
+      confirmedAtMs: 250,
+    })
+
+    expect(state.currentQuestionIndex).toBe(1)
+    expect(state.answers).toEqual([
+      { questionId: 'question-1', selectedAnswer: '8,000点' },
+    ])
+    expect(state.status).toBe('answering')
+    expect(state.elapsedTimeMs).toBe(150)
+  })
+
+  it('同じ問題への重複回答を保存しない', () => {
+    const answeredState = quizProgressReducer(
+      createQuizProgressState({ totalQuestions: 2, startedAtMs: 100 }),
+      {
+        type: 'confirmAnswer',
+        questionId: 'question-1',
+        selectedAnswer: '8,000点',
+        totalQuestions: 2,
+        confirmedAtMs: 250,
+      },
+    )
+
+    const state = quizProgressReducer(answeredState, {
+      type: 'confirmAnswer',
+      questionId: 'question-1',
+      selectedAnswer: '12,000点',
+      totalQuestions: 2,
+      confirmedAtMs: 300,
+    })
+
+    expect(state).toBe(answeredState)
+  })
+
+  it('最終回答で完了し、リセットで初期状態へ戻る', () => {
+    const firstAnsweredState = quizProgressReducer(
+      createQuizProgressState({ totalQuestions: 2, startedAtMs: 100 }),
+      {
+        type: 'confirmAnswer',
+        questionId: 'question-1',
+        selectedAnswer: '8,000点',
+        totalQuestions: 2,
+        confirmedAtMs: 250,
+      },
+    )
+    const completedState = quizProgressReducer(firstAnsweredState, {
+      type: 'confirmAnswer',
+      questionId: 'question-2',
+      selectedAnswer: '12,000点',
+      totalQuestions: 2,
+      confirmedAtMs: 400,
+    })
+
+    expect(completedState.status).toBe('completed')
+    expect(completedState.elapsedTimeMs).toBe(300)
+
+    expect(
+      quizProgressReducer(completedState, {
+        type: 'resetQuiz',
+        totalQuestions: 2,
+        startedAtMs: 500,
+      }),
+    ).toEqual(createQuizProgressState({ totalQuestions: 2, startedAtMs: 500 }))
+  })
+})

--- a/frontend/src/features/quiz/logic/quizProgressReducer.ts
+++ b/frontend/src/features/quiz/logic/quizProgressReducer.ts
@@ -1,0 +1,82 @@
+import type { QuizProgressState } from '../types/answer'
+
+export type QuizProgressAction =
+  | {
+      readonly type: 'confirmAnswer'
+      readonly questionId: string
+      readonly selectedAnswer: string
+      readonly totalQuestions: number
+      readonly confirmedAtMs: number
+    }
+  | {
+      readonly type: 'resetQuiz'
+      readonly totalQuestions: number
+      readonly startedAtMs: number
+    }
+
+type CreateQuizProgressStateArguments = {
+  readonly totalQuestions: number
+  readonly startedAtMs: number | null
+}
+
+export function createQuizProgressState({
+  totalQuestions,
+  startedAtMs,
+}: CreateQuizProgressStateArguments): QuizProgressState {
+  const hasQuestions = totalQuestions > 0
+
+  return {
+    currentQuestionIndex: 0,
+    answers: [],
+    status: hasQuestions ? 'answering' : 'completed',
+    startedAtMs: hasQuestions ? startedAtMs : null,
+    elapsedTimeMs: 0,
+  }
+}
+
+export function quizProgressReducer(
+  state: QuizProgressState,
+  action: QuizProgressAction,
+): QuizProgressState {
+  if (action.type === 'resetQuiz') {
+    return createQuizProgressState({
+      totalQuestions: action.totalQuestions,
+      startedAtMs: action.startedAtMs,
+    })
+  }
+
+  if (state.status === 'completed') {
+    return state
+  }
+
+  const isAlreadyAnswered = state.answers.some(
+    (answer) => answer.questionId === action.questionId,
+  )
+
+  if (isAlreadyAnswered) {
+    return state
+  }
+
+  const answers = [
+    ...state.answers,
+    {
+      questionId: action.questionId,
+      selectedAnswer: action.selectedAnswer,
+    },
+  ]
+  const isLastQuestion = state.currentQuestionIndex >= action.totalQuestions - 1
+  const elapsedTimeMs =
+    state.startedAtMs === null
+      ? 0
+      : Math.max(0, Math.round(action.confirmedAtMs - state.startedAtMs))
+
+  return {
+    currentQuestionIndex: isLastQuestion
+      ? state.currentQuestionIndex
+      : state.currentQuestionIndex + 1,
+    answers,
+    status: isLastQuestion ? 'completed' : 'answering',
+    startedAtMs: state.startedAtMs,
+    elapsedTimeMs,
+  }
+}

--- a/frontend/src/features/result/components/AnswerReviewPage.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.tsx
@@ -1,63 +1,12 @@
-import { DoraTiles, WinningHand } from '../../quiz'
 import type { ReviewedQuestion } from '../types/review'
+import { ReviewActions } from './ReviewActions'
+import { ReviewQuestionCard } from './ReviewQuestionCard'
 
 type AnswerReviewPageProps = {
   readonly reviewedQuestions: readonly ReviewedQuestion[]
   readonly onBack: () => void
   readonly onRetry: () => void
   readonly onTop: () => void
-}
-
-type ReviewActionsProps = {
-  readonly onBack: () => void
-  readonly onRetry: () => void
-  readonly onTop: () => void
-}
-
-const yakuReadings: Readonly<Record<string, string>> = {
-  断么九: 'タンヤオ',
-  平和: 'ピンフ',
-  一盃口: 'イーペーコー',
-  混一色: 'ホンイツ',
-  七対子: 'チートイツ',
-  清一色: 'チンイツ',
-  門前清自摸和: 'メンゼンツモ',
-  対々和: 'トイトイ',
-  '役牌 中': 'ヤクハイ チュン',
-}
-
-function getYakuDisplayName(name: string): string {
-  const reading = yakuReadings[name]
-
-  return reading === undefined ? name : `${name}（${reading}）`
-}
-
-function ReviewActions({ onBack, onRetry, onTop }: ReviewActionsProps) {
-  return (
-    <div className="flex w-full flex-col justify-center gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:gap-3">
-      <button
-        type="button"
-        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-4 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
-        onClick={onBack}
-      >
-        結果に戻る
-      </button>
-      <button
-        type="button"
-        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
-        onClick={onRetry}
-      >
-        もう一度挑戦
-      </button>
-      <button
-        type="button"
-        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
-        onClick={onTop}
-      >
-        トップ画面
-      </button>
-    </div>
-  )
 }
 
 export function AnswerReviewPage({
@@ -85,106 +34,14 @@ export function AnswerReviewPage({
         </header>
 
         <ol className="mt-6 space-y-5 sm:mt-8 sm:space-y-8">
-          {reviewedQuestions.map(
-            ({ question, selectedAnswer, isCorrect }, index) => {
-              const headingId = `review-question-${index + 1}`
-              const yakuLabel = question.yaku
-                .map((yaku) => `${getYakuDisplayName(yaku.name)}${yaku.han}翻`)
-                .join('、')
-
-              return (
-                <li key={question.id}>
-                  <article
-                    aria-labelledby={headingId}
-                    className="rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.55)] sm:rounded-xl sm:p-8"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <h2
-                        id={headingId}
-                        className="text-xl font-semibold sm:text-2xl"
-                      >
-                        問題 {index + 1}
-                      </h2>
-                      <span
-                        aria-label={`問題${index + 1}の判定`}
-                        className={`rounded-full border-2 px-5 py-1.5 text-base font-bold sm:text-lg ${
-                          isCorrect
-                            ? 'border-emerald-200 bg-emerald-950/90 text-emerald-100'
-                            : 'border-red-200 bg-red-950/90 text-red-100'
-                        }`}
-                      >
-                        {isCorrect ? '正解' : '不正解'}
-                      </span>
-                    </div>
-
-                    <div className="mt-4 rounded border border-[#c6a160]/70 bg-black/20 p-3 sm:mt-6 sm:p-5">
-                      <WinningHand hand={question.hand} />
-                    </div>
-
-                    <dl className="mt-4 grid gap-2 sm:mt-6 sm:grid-cols-2 sm:gap-3 lg:grid-cols-4">
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:col-span-2 sm:p-4 lg:col-span-4">
-                        <dt className="text-sm text-[#d4ae6b]">役</dt>
-                        <dd className="mt-1">{yakuLabel}</dd>
-                      </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-                        <dt className="text-sm text-[#d4ae6b]">翻</dt>
-                        <dd className="mt-1">{question.han}翻</dd>
-                      </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-                        <dt className="text-sm text-[#d4ae6b]">符</dt>
-                        <dd className="mt-1">
-                          {question.fu === null
-                            ? '計算不要（満貫以上）'
-                            : `${question.fu}符`}
-                        </dd>
-                      </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-                        <dt className="text-sm text-[#d4ae6b]">ドラ牌</dt>
-                        <dd className="mt-2">
-                          <DoraTiles tiles={question.doraTiles} compact />
-                        </dd>
-                      </div>
-                      <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-                        <dt className="text-sm text-[#d4ae6b]">ドラ枚数</dt>
-                        <dd className="mt-1">{question.dora}枚</dd>
-                      </div>
-                    </dl>
-
-                    <div className="mt-4 grid gap-3 sm:mt-6 sm:grid-cols-2 sm:gap-4">
-                      <div
-                        className={`rounded border-2 p-3 sm:p-4 ${
-                          isCorrect
-                            ? 'border-emerald-300 bg-emerald-950/85'
-                            : 'border-red-300 bg-red-950/85'
-                        }`}
-                      >
-                        <p className="text-sm text-[#d4ae6b]">選択した回答</p>
-                        <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
-                          {selectedAnswer ?? '未回答'}
-                        </p>
-                      </div>
-                      <div className="rounded border-2 border-emerald-300 bg-emerald-950/85 p-3 sm:p-4">
-                        <p className="text-sm text-[#d4ae6b]">正解</p>
-                        <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
-                          {question.correctAnswer}
-                        </p>
-                      </div>
-                    </div>
-
-                    <section
-                      aria-label={`問題${index + 1}の解説`}
-                      className="mt-4 rounded border border-[#c6a160] bg-[#031a14]/60 p-3 sm:mt-6 sm:p-5"
-                    >
-                      <h3 className="font-semibold text-[#d4ae6b]">解説</h3>
-                      <p className="mt-2 leading-relaxed text-[#f5e7c8]">
-                        {question.explanation}
-                      </p>
-                    </section>
-                  </article>
-                </li>
-              )
-            },
-          )}
+          {reviewedQuestions.map((reviewedQuestion, index) => (
+            <li key={reviewedQuestion.question.id}>
+              <ReviewQuestionCard
+                reviewedQuestion={reviewedQuestion}
+                questionNumber={index + 1}
+              />
+            </li>
+          ))}
         </ol>
 
         <div className="mt-8 sm:mt-10">

--- a/frontend/src/features/result/components/ReviewActions.tsx
+++ b/frontend/src/features/result/components/ReviewActions.tsx
@@ -1,0 +1,33 @@
+type ReviewActionsProps = {
+  readonly onBack: () => void
+  readonly onRetry: () => void
+  readonly onTop: () => void
+}
+
+export function ReviewActions({ onBack, onRetry, onTop }: ReviewActionsProps) {
+  return (
+    <div className="flex w-full flex-col justify-center gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:gap-3">
+      <button
+        type="button"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#f2e5c8] px-4 py-3 font-semibold text-[#063b2b] transition hover:bg-[#f8efd9] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
+        onClick={onBack}
+      >
+        結果に戻る
+      </button>
+      <button
+        type="button"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-[#123727] px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
+        onClick={onRetry}
+      >
+        もう一度挑戦
+      </button>
+      <button
+        type="button"
+        className="w-full cursor-pointer rounded border-2 border-[#c6a160] bg-transparent px-4 py-3 font-semibold text-[#f1d49e] transition hover:bg-[#1b4b36] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f1d49e] sm:w-auto sm:px-6"
+        onClick={onTop}
+      >
+        トップ画面
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/result/components/ReviewQuestionCard.tsx
+++ b/frontend/src/features/result/components/ReviewQuestionCard.tsx
@@ -1,0 +1,100 @@
+import { DoraTiles, WinningHand } from '../../quiz'
+import type { ReviewedQuestion } from '../types/review'
+import { formatYakuLabel } from '../utils/formatYakuLabel'
+
+type ReviewQuestionCardProps = {
+  readonly reviewedQuestion: ReviewedQuestion
+  readonly questionNumber: number
+}
+
+export function ReviewQuestionCard({
+  reviewedQuestion: { question, selectedAnswer, isCorrect },
+  questionNumber,
+}: ReviewQuestionCardProps) {
+  const headingId = `review-question-${questionNumber}`
+
+  return (
+    <article
+      aria-labelledby={headingId}
+      className="rounded-lg border-2 border-[#c6a160] bg-[#082f25]/95 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.55)] sm:rounded-xl sm:p-8"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 id={headingId} className="text-xl font-semibold sm:text-2xl">
+          問題 {questionNumber}
+        </h2>
+        <span
+          aria-label={`問題${questionNumber}の判定`}
+          className={`rounded-full border-2 px-5 py-1.5 text-base font-bold sm:text-lg ${
+            isCorrect
+              ? 'border-emerald-200 bg-emerald-950/90 text-emerald-100'
+              : 'border-red-200 bg-red-950/90 text-red-100'
+          }`}
+        >
+          {isCorrect ? '正解' : '不正解'}
+        </span>
+      </div>
+
+      <div className="mt-4 rounded border border-[#c6a160]/70 bg-black/20 p-3 sm:mt-6 sm:p-5">
+        <WinningHand hand={question.hand} />
+      </div>
+
+      <dl className="mt-4 grid gap-2 sm:mt-6 sm:grid-cols-2 sm:gap-3 lg:grid-cols-4">
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:col-span-2 sm:p-4 lg:col-span-4">
+          <dt className="text-sm text-[#d4ae6b]">役</dt>
+          <dd className="mt-1">{formatYakuLabel(question.yaku)}</dd>
+        </div>
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
+          <dt className="text-sm text-[#d4ae6b]">翻</dt>
+          <dd className="mt-1">{question.han}翻</dd>
+        </div>
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
+          <dt className="text-sm text-[#d4ae6b]">符</dt>
+          <dd className="mt-1">
+            {question.fu === null ? '計算不要（満貫以上）' : `${question.fu}符`}
+          </dd>
+        </div>
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
+          <dt className="text-sm text-[#d4ae6b]">ドラ牌</dt>
+          <dd className="mt-2">
+            <DoraTiles tiles={question.doraTiles} compact />
+          </dd>
+        </div>
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
+          <dt className="text-sm text-[#d4ae6b]">ドラ枚数</dt>
+          <dd className="mt-1">{question.dora}枚</dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 grid gap-3 sm:mt-6 sm:grid-cols-2 sm:gap-4">
+        <div
+          className={`rounded border-2 p-3 sm:p-4 ${
+            isCorrect
+              ? 'border-emerald-300 bg-emerald-950/85'
+              : 'border-red-300 bg-red-950/85'
+          }`}
+        >
+          <p className="text-sm text-[#d4ae6b]">選択した回答</p>
+          <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
+            {selectedAnswer ?? '未回答'}
+          </p>
+        </div>
+        <div className="rounded border-2 border-emerald-300 bg-emerald-950/85 p-3 sm:p-4">
+          <p className="text-sm text-[#d4ae6b]">正解</p>
+          <p className="mt-1 break-words text-lg font-semibold sm:text-xl">
+            {question.correctAnswer}
+          </p>
+        </div>
+      </div>
+
+      <section
+        aria-label={`問題${questionNumber}の解説`}
+        className="mt-4 rounded border border-[#c6a160] bg-[#031a14]/60 p-3 sm:mt-6 sm:p-5"
+      >
+        <h3 className="font-semibold text-[#d4ae6b]">解説</h3>
+        <p className="mt-2 leading-relaxed text-[#f5e7c8]">
+          {question.explanation}
+        </p>
+      </section>
+    </article>
+  )
+}

--- a/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
+++ b/frontend/src/features/result/containers/AnswerReviewPageContainer.tsx
@@ -1,5 +1,6 @@
 import type { QuizResult } from '../../quiz'
 import { AnswerReviewPage } from '../components/AnswerReviewPage'
+import { createReviewedQuestions } from '../logic/createReviewedQuestions'
 
 type AnswerReviewPageContainerProps = {
   readonly result: QuizResult
@@ -14,19 +15,7 @@ export function AnswerReviewPageContainer({
   onRetry,
   onTop,
 }: AnswerReviewPageContainerProps) {
-  const answerByQuestionId = new Map(
-    result.answers.map((answer) => [answer.questionId, answer]),
-  )
-  const reviewedQuestions = result.questions.map((question) => {
-    const answer = answerByQuestionId.get(question.id)
-    const selectedAnswer = answer?.selectedAnswer ?? null
-
-    return {
-      question,
-      selectedAnswer,
-      isCorrect: selectedAnswer === question.correctAnswer,
-    }
-  })
+  const reviewedQuestions = createReviewedQuestions(result)
 
   return (
     <AnswerReviewPage

--- a/frontend/src/features/result/logic/createReviewedQuestions.test.ts
+++ b/frontend/src/features/result/logic/createReviewedQuestions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { questions } from '../../quiz'
+import { createReviewedQuestions } from './createReviewedQuestions'
+
+describe('createReviewedQuestions', () => {
+  it('回答履歴を問題と突合して選択回答と正誤を生成する', () => {
+    const selectedQuestions = questions.slice(0, 3)
+    const reviewedQuestions = createReviewedQuestions({
+      questions: selectedQuestions,
+      answers: [
+        {
+          questionId: selectedQuestions[0].id,
+          selectedAnswer: selectedQuestions[0].correctAnswer,
+        },
+        {
+          questionId: selectedQuestions[1].id,
+          selectedAnswer: selectedQuestions[1].choices[0],
+        },
+      ],
+    })
+
+    expect(reviewedQuestions[0]).toMatchObject({ isCorrect: true })
+    expect(reviewedQuestions[1]).toMatchObject({
+      selectedAnswer: selectedQuestions[1].choices[0],
+      isCorrect:
+        selectedQuestions[1].choices[0] === selectedQuestions[1].correctAnswer,
+    })
+    expect(reviewedQuestions[2]).toMatchObject({
+      selectedAnswer: null,
+      isCorrect: false,
+    })
+  })
+})

--- a/frontend/src/features/result/logic/createReviewedQuestions.ts
+++ b/frontend/src/features/result/logic/createReviewedQuestions.ts
@@ -1,0 +1,27 @@
+import type { QuizResult } from '../../quiz'
+import type { ReviewedQuestion } from '../types/review'
+
+type CreateReviewedQuestionsArguments = Pick<
+  QuizResult,
+  'questions' | 'answers'
+>
+
+export function createReviewedQuestions({
+  questions,
+  answers,
+}: CreateReviewedQuestionsArguments): readonly ReviewedQuestion[] {
+  const answerByQuestionId = new Map(
+    answers.map((answer) => [answer.questionId, answer]),
+  )
+
+  return questions.map((question) => {
+    const selectedAnswer =
+      answerByQuestionId.get(question.id)?.selectedAnswer ?? null
+
+    return {
+      question,
+      selectedAnswer,
+      isCorrect: selectedAnswer === question.correctAnswer,
+    }
+  })
+}

--- a/frontend/src/features/result/utils/formatYakuLabel.test.ts
+++ b/frontend/src/features/result/utils/formatYakuLabel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatYakuLabel } from './formatYakuLabel'
+
+describe('formatYakuLabel', () => {
+  it('正式名称・読み・翻数を組み合わせる', () => {
+    expect(
+      formatYakuLabel([
+        { name: '七対子', han: 2 },
+        { name: 'リーチ', han: 1 },
+      ]),
+    ).toBe('七対子（チートイツ）2翻、リーチ1翻')
+  })
+
+  it('読みが未登録の役名は正式名称をそのまま使う', () => {
+    expect(formatYakuLabel([{ name: 'テスト役', han: 1 }])).toBe('テスト役1翻')
+  })
+})

--- a/frontend/src/features/result/utils/formatYakuLabel.ts
+++ b/frontend/src/features/result/utils/formatYakuLabel.ts
@@ -1,0 +1,25 @@
+import type { Yaku } from '../../quiz'
+
+const yakuReadings: Readonly<Record<string, string>> = {
+  断么九: 'タンヤオ',
+  平和: 'ピンフ',
+  一盃口: 'イーペーコー',
+  混一色: 'ホンイツ',
+  七対子: 'チートイツ',
+  清一色: 'チンイツ',
+  門前清自摸和: 'メンゼンツモ',
+  対々和: 'トイトイ',
+  '役牌 中': 'ヤクハイ チュン',
+}
+
+function getYakuDisplayName(name: string): string {
+  const reading = yakuReadings[name]
+
+  return reading === undefined ? name : `${name}（${reading}）`
+}
+
+export function formatYakuLabel(yaku: readonly Yaku[]): string {
+  return yaku
+    .map((item) => `${getYakuDisplayName(item.name)}${item.han}翻`)
+    .join('、')
+}


### PR DESCRIPTION
## 概要

責務が集中していたコンポーネント・Hook・Containerを確認し、処理を責務ごとに分割しました。

## 対応内容

- `useQuizProgress`から状態遷移と計時処理をReducerへ分離
- `QuizPageContainer`から結果生成処理を純粋関数へ分離
- 解説用データの生成と正誤判定を純粋関数へ分離
- 解説画面を以下のコンポーネントへ分割
  - 問題ごとの解説カード
  - 操作ボタン
  - 役名の表示整形
- 分割した処理の単体テストを追加
- 出題・採点・ランク判定が既に純粋関数へ分離されていることを確認

## 動作確認

- [x] Prettierが成功する
- [x] ESLintが成功する
- [x] 全106テストが成功する
- [x] 本番用ビルドが成功する

Closes #29