### PR TITLE
問題画面に現在の問題番号を表示

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -14,9 +14,7 @@ describe('App routing', () => {
 
     await user.click(screen.getByRole('button', { name: 'スタート' }))
 
-    expect(
-      screen.getByRole('heading', { name: '10問出題' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '1問目' })).toBeInTheDocument()
   })
 
   it('フッターから利用規約ページへ移動し、トップ画面へ戻れる', async () => {
@@ -68,9 +66,7 @@ describe('App routing', () => {
       </MemoryRouter>,
     )
 
-    expect(
-      screen.getByRole('heading', { name: '10問出題' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '1問目' })).toBeInTheDocument()
   })
 
   it('選択肢から回答すると次の問題へ進む', async () => {
@@ -89,6 +85,7 @@ describe('App routing', () => {
     expect(
       screen.getByRole('progressbar', { name: '問題の進捗' }),
     ).toHaveAttribute('aria-valuenow', '1')
+    expect(screen.getByRole('heading', { name: '2問目' })).toBeInTheDocument()
   })
 
   it('問題画面の中断するボタンから確認なしでトップ画面へ戻る', async () => {
@@ -163,7 +160,7 @@ describe('App routing', () => {
     await user.click(screen.getByRole('button', { name: 'もう一度挑戦' }))
 
     expect(
-      await screen.findByRole('heading', { name: '10問出題' }),
+      await screen.findByRole('heading', { name: '1問目' }),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('heading', { name: 'スコア', level: 1 }),
@@ -185,9 +182,7 @@ describe('App routing', () => {
 
     await user.click(screen.getByRole('button', { name: 'スタート' }))
 
-    expect(
-      screen.getByRole('heading', { name: '10問出題' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '1問目' })).toBeInTheDocument()
     expect(
       screen.getByRole('progressbar', { name: '問題の進捗' }),
     ).toHaveAttribute('aria-valuenow', '0')

--- a/frontend/src/features/quiz/components/QuizPage.test.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.test.tsx
@@ -16,9 +16,7 @@ describe('QuizPage', () => {
       />,
     )
 
-    expect(
-      screen.getByRole('heading', { name: '10問出題' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '1問目' })).toBeInTheDocument()
     const progressbar = screen.getByRole('progressbar', { name: '問題の進捗' })
 
     expect(progressbar).toHaveAttribute('aria-valuenow', '0')
@@ -64,6 +62,7 @@ describe('QuizPage', () => {
     const progressbar = screen.getByRole('progressbar', { name: '問題の進捗' })
 
     expect(progressbar).toHaveAttribute('aria-valuenow', '1')
+    expect(screen.getByRole('heading', { name: '2問目' })).toBeInTheDocument()
     expect(
       progressbar.querySelectorAll('[data-state="completed"]'),
     ).toHaveLength(1)

--- a/frontend/src/features/quiz/components/QuizPage.tsx
+++ b/frontend/src/features/quiz/components/QuizPage.tsx
@@ -52,7 +52,7 @@ export function QuizPage({
               </button>
             </div>
             <h1 className="text-3xl font-semibold sm:text-4xl [@media(min-width:640px)_and_(max-height:900px)]:text-2xl">
-              {totalQuestions}問出題
+              {currentQuestionNumber}問目
             </h1>
             <div
               role="progressbar"

--- a/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
+++ b/frontend/src/features/quiz/containers/QuizPageContainer.test.tsx
@@ -18,13 +18,12 @@ describe('QuizPageContainer', () => {
     expect(
       screen.getByRole('progressbar', { name: '問題の進捗' }),
     ).toHaveAttribute('aria-valuenow', '1')
+    expect(screen.getByRole('heading', { name: '2問目' })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: '中断する' }))
 
     expect(onQuit).toHaveBeenCalledOnce()
-    expect(
-      screen.getByRole('heading', { name: '10問出題' }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '1問目' })).toBeInTheDocument()
     expect(
       screen.getByRole('progressbar', { name: '問題の進捗' }),
     ).toHaveAttribute('aria-valuenow', '0')


### PR DESCRIPTION
## 概要

問題画面に現在何問目を回答しているか表示するよう変更しました。

Closes #74

## 変更内容

- 問題画面の見出しを「10問出題」から「1問目」形式へ変更
- 回答後、現在の問題番号に合わせて表示を更新
- 再挑戦や中断によるリセット後は「1問目」から表示
- 問題番号表示に関するコンポーネント・画面遷移テストを更新
- 出題総数は引き続き`QUIZ_QUESTION_COUNT`を参照

## 動作確認

- [x] `npm run test:run`（115 tests passed）
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`
