### PR TITLE
解説画面の牌姿をスマートフォン幅に収める

### DIFF
--- a/frontend/src/features/quiz/components/MahjongTile.tsx
+++ b/frontend/src/features/quiz/components/MahjongTile.tsx
@@ -8,7 +8,7 @@ type MahjongTileProps = {
 }
 
 const sizeClasses = {
-  default: 'w-8 sm:w-10 md:w-12 lg:w-14',
+  default: 'w-[clamp(0.875rem,4.8vw,2rem)] sm:w-10 md:w-12 lg:w-14',
   large:
     'w-[clamp(1rem,5.6vw,2.25rem)] sm:w-12 md:w-14 lg:w-16 xl:w-[4.5rem] [@media(min-width:640px)_and_(max-height:900px)]:w-12',
 } as const

--- a/frontend/src/features/quiz/components/WinningHand.test.tsx
+++ b/frontend/src/features/quiz/components/WinningHand.test.tsx
@@ -13,6 +13,9 @@ describe('WinningHand', () => {
 
     expect(screen.queryByText('手牌')).not.toBeInTheDocument()
     expect(within(concealedTiles).getAllByRole('img')).toHaveLength(13)
+    expect(within(concealedTiles).getAllByRole('img')[0]).toHaveClass(
+      'w-[clamp(0.875rem,4.8vw,2rem)]',
+    )
     expect(within(winningTile).getAllByRole('img')).toHaveLength(1)
   })
 


### PR DESCRIPTION
## 概要

スマートフォンの解説画面で牌姿の一部がカードから見切れる問題を修正しました。

## 原因

解説画面で使用する通常サイズの麻雀牌が、スマートフォンでも32px固定になっていました。牌列の横スクロールを抑えるレイアウトに対して牌幅が大きく、カード幅を超えていました。

## 変更内容

- 通常サイズの麻雀牌を画面幅に応じて縮小
- スマートフォンでは約14〜32pxの範囲で牌幅を調整
- タブレット・PCでは既存の牌サイズを維持
- 通常サイズのレスポンシブ指定を確認するテストを追加

## 表示確認

- 320px幅：14枚すべてカード内に表示
- 375px幅：14枚すべてカード内に表示
- 牌列の横スクロールなし
- ページ全体の横スクロールなし

## 動作確認

- [x] `npm run test:run`（116 tests passed）
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`
