### PR TITLE
解説画面の牌表示修正をmainへ反映

### DIFF
--- a/frontend/src/features/quiz/components/MahjongTile.tsx
+++ b/frontend/src/features/quiz/components/MahjongTile.tsx
@@ -8,7 +8,7 @@ type MahjongTileProps = {
 }
 
 const sizeClasses = {
-  default: 'w-8 sm:w-10 md:w-12 lg:w-14',
+  default: 'w-[clamp(0.875rem,4.8vw,2rem)] sm:w-10 md:w-12 lg:w-14',
   large:
     'w-[clamp(1rem,5.6vw,2.25rem)] sm:w-12 md:w-14 lg:w-16 xl:w-[4.5rem] [@media(min-width:640px)_and_(max-height:900px)]:w-12',
 } as const

--- a/frontend/src/features/quiz/components/WinningHand.test.tsx
+++ b/frontend/src/features/quiz/components/WinningHand.test.tsx
@@ -13,6 +13,9 @@ describe('WinningHand', () => {
 
     expect(screen.queryByText('手牌')).not.toBeInTheDocument()
     expect(within(concealedTiles).getAllByRole('img')).toHaveLength(13)
+    expect(within(concealedTiles).getAllByRole('img')[0]).toHaveClass(
+      'w-[clamp(0.875rem,4.8vw,2rem)]',
+    )
     expect(within(winningTile).getAllByRole('img')).toHaveLength(1)
   })
 


### PR DESCRIPTION
## 概要

`develop`ブランチへマージ済みの、スマートフォンにおける解説画面の牌表示修正を`main`ブランチへ反映します。

## 反映するPR

- #79 解説画面の牌姿をスマートフォン幅に収める

## 修正内容

- 解説画面で使用する麻雀牌を画面幅に応じて縮小
- スマートフォンでは約14〜32pxの範囲で牌幅を調整
- 牌姿全体が解説カード内に収まるよう修正
- タブレット・PCでは既存の牌サイズを維持
- 通常サイズのレスポンシブ指定を確認するテストを追加

## 表示確認

- 320px幅：14枚すべてカード内に表示
- 375px幅：14枚すべてカード内に表示
- 牌列の横スクロールなし
- ページ全体の横スクロールなし

## 動作確認

- [x] `npm run test:run`（116 tests passed）
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`

## デプロイ

`main`へのマージ後、Vercelの本番環境へ修正が反映されることを確認します。