### PR TITLE
解説画面と結果画面の表示改善をmainへ反映

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -117,10 +117,10 @@ describe('App routing', () => {
     }
 
     expect(
-      await screen.findByRole('heading', { name: 'スコア', level: 1 }),
+      await screen.findByRole('heading', { name: '今回の結果', level: 1 }),
     ).toBeInTheDocument()
     expect(screen.getByLabelText('ランク')).toBeInTheDocument()
-    expect(screen.getAllByText('スコア')).toHaveLength(2)
+    expect(screen.getByText('スコア')).toBeInTheDocument()
     expect(screen.getByText('正解数')).toBeInTheDocument()
     expect(screen.getByText('回答時間')).toBeInTheDocument()
 
@@ -134,7 +134,7 @@ describe('App routing', () => {
     await user.click(screen.getAllByRole('button', { name: '結果に戻る' })[0])
 
     expect(
-      await screen.findByRole('heading', { name: 'スコア', level: 1 }),
+      await screen.findByRole('heading', { name: '今回の結果', level: 1 }),
     ).toBeInTheDocument()
   })
 
@@ -154,7 +154,7 @@ describe('App routing', () => {
     }
 
     expect(
-      await screen.findByRole('heading', { name: 'スコア', level: 1 }),
+      await screen.findByRole('heading', { name: '今回の結果', level: 1 }),
     ).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'もう一度挑戦' }))
@@ -163,7 +163,7 @@ describe('App routing', () => {
       await screen.findByRole('heading', { name: '1問目' }),
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('heading', { name: 'スコア', level: 1 }),
+      screen.queryByRole('heading', { name: '今回の結果', level: 1 }),
     ).not.toBeInTheDocument()
 
     await user.click(
@@ -204,7 +204,7 @@ describe('App routing', () => {
     }
 
     expect(
-      await screen.findByRole('heading', { name: 'スコア', level: 1 }),
+      await screen.findByRole('heading', { name: '今回の結果', level: 1 }),
     ).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'トップ画面' }))

--- a/frontend/src/features/result/components/AnswerReviewPage.test.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.test.tsx
@@ -16,7 +16,7 @@ const reviewedQuestions: ReviewedQuestion[] = questions
   }))
 
 describe('AnswerReviewPage', () => {
-  it('10問分の正誤・回答・役・翻・符・ドラ牌・ドラ枚数・解説を表示する', () => {
+  it('10問分の正誤・回答・ドラを含む役・翻・符・解説を表示する', () => {
     render(
       <AnswerReviewPage
         reviewedQuestions={reviewedQuestions}
@@ -47,14 +47,20 @@ describe('AnswerReviewPage', () => {
     )
     expect(
       within(firstQuestion).getByText(
-        '断么九（タンヤオ）1翻、平和（ピンフ）1翻、一盃口（イーペーコー）1翻、リーチ1翻',
+        '断么九（タンヤオ）1翻、平和（ピンフ）1翻、一盃口（イーペーコー）1翻、リーチ1翻、ドラ1翻',
       ),
     ).toBeInTheDocument()
     expect(within(firstQuestion).getByText('役')).toBeInTheDocument()
     expect(within(firstQuestion).getByLabelText('自家 南家')).toHaveClass(
-      'text-2xl',
-      'sm:text-3xl',
+      'text-xs',
+      'sm:text-base',
     )
+    expect(within(firstQuestion).getByText('ドラ')).toBeInTheDocument()
+    expect(
+      within(
+        within(firstQuestion).getByRole('group', { name: 'ドラ牌' }),
+      ).getAllByRole('img'),
+    ).toHaveLength(1)
     expect(screen.getAllByText(/門前清自摸和（メンゼンツモ）1翻/)).toHaveLength(
       2,
     )
@@ -62,13 +68,10 @@ describe('AnswerReviewPage', () => {
     expect(
       within(firstQuestion).getByText('計算不要（満貫以上）'),
     ).toBeInTheDocument()
+    expect(within(firstQuestion).queryByText('ドラ牌')).not.toBeInTheDocument()
     expect(
-      within(
-        within(firstQuestion).getByRole('group', { name: 'ドラ牌' }),
-      ).getAllByRole('img'),
-    ).toHaveLength(1)
-    expect(within(firstQuestion).getByText('ドラ枚数')).toBeInTheDocument()
-    expect(within(firstQuestion).getByText('1枚')).toBeInTheDocument()
+      within(firstQuestion).queryByText('ドラ枚数'),
+    ).not.toBeInTheDocument()
     expect(
       within(firstQuestion).getByText(questions[0].explanation),
     ).toBeInTheDocument()
@@ -79,11 +82,13 @@ describe('AnswerReviewPage', () => {
       within(secondQuestion).getByLabelText('自家 東家'),
     ).toBeInTheDocument()
     expect(
+      within(secondQuestion).queryByText(/ドラ\d+翻/),
+    ).not.toBeInTheDocument()
+    expect(
       within(
         within(secondQuestion).getByRole('group', { name: 'ドラ牌' }),
       ).getByText('なし'),
     ).toBeInTheDocument()
-    expect(within(secondQuestion).getByText('0枚')).toBeInTheDocument()
 
     expect(
       screen
@@ -91,6 +96,15 @@ describe('AnswerReviewPage', () => {
         .slice(0, 3)
         .map((button) => button.textContent),
     ).toEqual(['もう一度挑戦', '結果に戻る', 'トップ画面'])
+    const header = screen.getByRole('heading', {
+      name: '解説',
+      level: 1,
+    }).parentElement!.parentElement!
+
+    expect(header.children[0]).toHaveClass('order-1', 'sm:order-2')
+    expect(header.children[1]).toContainElement(
+      screen.getByRole('heading', { name: '解説', level: 1 }),
+    )
     for (const button of screen.getAllByRole('button')) {
       expect(button).not.toHaveClass('border-[#c6a160]')
     }

--- a/frontend/src/features/result/components/AnswerReviewPage.tsx
+++ b/frontend/src/features/result/components/AnswerReviewPage.tsx
@@ -24,12 +24,14 @@ export function AnswerReviewPage({
 
       <div className="relative mx-auto w-full max-w-6xl">
         <header className="flex flex-col items-center gap-4 text-center sm:flex-row sm:justify-between sm:gap-5 sm:text-left">
-          <div>
+          <div className="order-1 w-full sm:order-2 sm:w-auto">
+            <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
+          </div>
+          <div className="order-2 sm:order-1">
             <h1 className="text-2xl font-semibold tracking-[0.08em] sm:text-4xl sm:tracking-[0.12em]">
               解説
             </h1>
           </div>
-          <ReviewActions onBack={onBack} onRetry={onRetry} onTop={onTop} />
         </header>
 
         <ol className="mt-6 space-y-5 sm:mt-8 sm:space-y-8">

--- a/frontend/src/features/result/components/ResultPage.test.tsx
+++ b/frontend/src/features/result/components/ResultPage.test.tsx
@@ -24,7 +24,7 @@ const rankCriterion: RankCriterion = {
 }
 
 describe('ResultPage', () => {
-  it('スコア・ランク・習熟度・正解数・回答時間を表示する', async () => {
+  it('今回の結果・スコア・ランク・習熟度・正解数・回答時間を表示する', async () => {
     const onReview = vi.fn()
     const onRetry = vi.fn()
     const onTop = vi.fn()
@@ -39,7 +39,7 @@ describe('ResultPage', () => {
     )
 
     expect(
-      screen.getByRole('heading', { name: 'スコア', level: 1 }),
+      screen.getByRole('heading', { name: '今回の結果', level: 1 }),
     ).toBeInTheDocument()
     expect(screen.getByLabelText('ランク')).toHaveTextContent('S')
     expect(screen.getByLabelText('ランク')).toHaveClass('text-[#d946ef]')

--- a/frontend/src/features/result/components/ResultPage.tsx
+++ b/frontend/src/features/result/components/ResultPage.tsx
@@ -44,7 +44,7 @@ export function ResultPage({
 
       <section className="relative w-full max-w-4xl rounded-xl bg-[#0d4938] px-4 py-6 text-center shadow-[0_18px_44px_rgba(0,0,0,0.78),inset_0_1px_0_rgba(255,255,255,0.1)] sm:px-8 sm:py-10 lg:px-10 lg:py-12">
         <h1 className="text-3xl font-semibold tracking-[0.15em] [text-shadow:0_0_18px_rgba(250,204,21,0.45)] sm:text-4xl">
-          スコア
+          今回の結果
         </h1>
 
         <div className="relative isolate mt-6 sm:mt-8">

--- a/frontend/src/features/result/components/ReviewQuestionCard.tsx
+++ b/frontend/src/features/result/components/ReviewQuestionCard.tsx
@@ -19,6 +19,9 @@ export function ReviewQuestionCard({
     north: '北',
   } as const
   const seatWindLabel = `${windLabels[question.condition.seatWind]}家`
+  const yakuLabel = formatYakuLabel(question.yaku)
+  const yakuWithDoraLabel =
+    question.dora > 0 ? `${yakuLabel}、ドラ${question.dora}翻` : yakuLabel
 
   return (
     <article
@@ -62,20 +65,28 @@ export function ReviewQuestionCard({
         </div>
       </div>
 
-      <div className="relative mt-4 rounded border border-[#c6a160]/70 bg-[#031f18]/90 px-3 pt-16 pb-3 shadow-inner shadow-black/25 sm:mt-6 sm:px-5 sm:pt-20 sm:pb-5">
-        <span
-          aria-label={`自家 ${seatWindLabel}`}
-          className="absolute top-3 left-3 rounded bg-[#f3e8ce] px-4 py-2 text-2xl font-black text-[#031a14] shadow-md sm:top-5 sm:left-5 sm:px-5 sm:text-3xl"
-        >
-          {seatWindLabel}
-        </span>
+      <div className="relative mt-4 rounded border border-[#c6a160]/70 bg-[#031f18]/90 px-3 pt-12 pb-3 shadow-inner shadow-black/25 sm:mt-6 sm:px-5 sm:pt-20 sm:pb-5">
+        <div className="absolute top-2 left-2 flex items-center gap-4 sm:top-3 sm:left-3 sm:gap-6">
+          <span
+            aria-label={`自家 ${seatWindLabel}`}
+            className="rounded bg-[#f3e8ce] px-2 py-1 text-xs font-black text-[#031a14] shadow-md sm:px-2.5 sm:py-1 sm:text-base"
+          >
+            {seatWindLabel}
+          </span>
+          <div className="flex items-center gap-1.5 sm:gap-2">
+            <span className="text-xs font-semibold text-white sm:text-base">
+              ドラ
+            </span>
+            <DoraTiles tiles={question.doraTiles} compact />
+          </div>
+        </div>
         <WinningHand hand={question.hand} />
       </div>
 
-      <dl className="mt-4 grid gap-2 sm:mt-6 sm:grid-cols-2 sm:gap-3 lg:grid-cols-4">
-        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:col-span-2 sm:p-4 lg:col-span-4">
+      <dl className="mt-4 grid gap-2 sm:mt-6 sm:grid-cols-2 sm:gap-3">
+        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:col-span-2 sm:p-4">
           <dt className="text-sm font-medium text-white">役</dt>
-          <dd className="mt-1">{formatYakuLabel(question.yaku)}</dd>
+          <dd className="mt-1">{yakuWithDoraLabel}</dd>
         </div>
         <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
           <dt className="text-sm font-medium text-white">翻</dt>
@@ -86,16 +97,6 @@ export function ReviewQuestionCard({
           <dd className="mt-1">
             {question.fu === null ? '計算不要（満貫以上）' : `${question.fu}符`}
           </dd>
-        </div>
-        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-          <dt className="text-sm font-medium text-white">ドラ牌</dt>
-          <dd className="mt-2">
-            <DoraTiles tiles={question.doraTiles} compact />
-          </dd>
-        </div>
-        <div className="rounded border border-[#c6a160]/50 bg-black/20 p-3 sm:p-4">
-          <dt className="text-sm font-medium text-white">ドラ枚数</dt>
-          <dd className="mt-1">{question.dora}枚</dd>
         </div>
       </dl>
 


### PR DESCRIPTION
## 概要

`develop`ブランチで確認済みの解説画面・結果画面の表示改善を、`main`ブランチへ反映します。

## 反映するPR

- #81 解説画面と結果画面の表示を調整

## 変更内容

### 解説画面

- 東家・南家などの自家バッジを約半分のサイズへ縮小
- 自家バッジの右隣に間隔を空けて「ドラ」と対象牌を表示
- ドラがない場合は「ドラ なし」と表示
- 役欄へ`ドラ1翻`の形式でドラを追加
- 独立していた「ドラ牌」「ドラ枚数」の詳細ブロックを削除
- スマートフォンでは操作ボタン3つを「解説」タイトルの上へ移動
- PCではタイトル左・操作ボタン右の配置を維持

### 結果画面

- メインタイトルを「スコア」から「今回の結果」へ変更
- 得点項目の「スコア」ラベルは維持

## 動作確認

- [x] `npm run test:run`（116 tests passed）
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`

## デプロイ

`main`へのマージ後、Vercelの本番環境へ反映されることを確認します。
